### PR TITLE
Update MainMenu VBS4 button placement

### DIFF
--- a/PythonPorjects/STE_Toolkit.py
+++ b/PythonPorjects/STE_Toolkit.py
@@ -949,16 +949,6 @@ class MainMenu(tk.Frame):
             bg="black", fg="white", pady=20
         ).pack(fill="x")
 
-        # VBS4 Button
-        tk.Button(
-            self,
-            text="Launch VBS4",
-            font=("Helvetica", 24),
-            bg="#444444", fg="white",
-            width=30, height=1,
-            command=launch_vbs4
-        ).pack(pady=10)
-
         # BlueIG Frame (dynamic)
         self.blueig_frame = tk.Frame(self, bg="#333333")
         self.blueig_frame.pack(pady=10)
@@ -966,21 +956,35 @@ class MainMenu(tk.Frame):
 
         # Other buttons
         for txt, cmd in [
+            ("Launch VBS4", launch_vbs4),
             ("Launch BVI", launch_bvi),
             ("Settings", lambda: controller.show("Settings")),
             ("Tutorials", lambda: controller.show("Tutorials")),
             ("Credits", lambda: controller.show("Credits")),
             ("Exit", controller.destroy),
         ]:
-            button = tk.Button(
-                self,
-                text=txt,
-                font=("Helvetica", 24),
-                bg="#444444", fg="white",
-                width=30, height=1,
-                command=cmd
-            )
-            button.pack(pady=10)
+            if txt == "Launch VBS4":
+                self.create_vbs4_button()
+            else:
+                button = tk.Button(
+                    self,
+                    text=txt,
+                    font=("Helvetica", 24),
+                    bg="#444444", fg="white",
+                    width=30, height=1,
+                    command=cmd
+                )
+                button.pack(pady=10)
+
+    def create_vbs4_button(self):
+        tk.Button(
+            self,
+            text="Launch VBS4",
+            font=("Helvetica", 24),
+            bg="#444444", fg="white",
+            width=30, height=1,
+            command=launch_vbs4
+        ).pack(pady=10, before=self.blueig_frame)
 
     def create_blueig_button(self):
         for widget in self.blueig_frame.winfo_children():


### PR DESCRIPTION
## Summary
- insert `Launch VBS4` into the Main Menu button loop
- move VBS4 button creation to new `create_vbs4_button()`
- pack VBS4 button before the BlueIG frame

## Testing
- `python3 -m py_compile PythonPorjects/STE_Toolkit.py`

------
https://chatgpt.com/codex/tasks/task_e_6850369401348322b3c613a8dd253625

## Summary by Sourcery

Streamline and adjust the Main Menu’s “Launch VBS4” button by moving its creation into the button loop and repositioning it before the BlueIG frame

Enhancements:
- Refactor VBS4 button creation into a new create_vbs4_button method
- Include “Launch VBS4” in the main menu button loop alongside other items
- Pack the VBS4 button before the BlueIG frame to adjust its placement