### PR TITLE
Improve version detection in STE Toolkit

### DIFF
--- a/PythonPorjects/STE_Toolkit.py
+++ b/PythonPorjects/STE_Toolkit.py
@@ -44,18 +44,43 @@ def get_vbs4_install_path() -> str:
 
     return ''
 
+
+def get_vbs4_launcher_path() -> str:
+    """Return the saved VBS4 launcher or try to find it near the VBS4 install."""
+    path = config['General'].get('vbs4_setup_path', '')
+    if path and os.path.isfile(path):
+        return path
+
+    vbs4_exe = get_vbs4_install_path()
+    if vbs4_exe:
+        base = os.path.dirname(vbs4_exe)
+        candidates = [
+            os.path.join(base, 'VBSLauncher.exe'),
+            os.path.join(os.path.dirname(base), 'VBSLauncher.exe'),
+        ]
+        for cand in candidates:
+            if os.path.isfile(cand):
+                return cand
+
+    found = find_executable('VBSLauncher.exe')
+    if found and os.path.isfile(found):
+        return found
+
+    return ''
+
 #==============================================================================
 # VERSION DISPLAY FUNCTIONS
 #==============================================================================
 
 def get_vbs4_version(file_path):
     """Extract VBS4 version from the file path."""
-    match = re.search(r'VBS4 (\d+\.\d+)', file_path)
+    # handle paths like ".../VBS4/25.1/VBS4.exe" or "VBS4 25.1" etc.
+    match = re.search(r'VBS4[\\/\s_-]*([0-9]+(?:\.[0-9]+)*)', file_path, re.IGNORECASE)
     return match.group(1) if match else "Unknown"
 
 def get_blueig_version(file_path):
     """Extract BlueIG version from the file path."""
-    match = re.search(r'Blue IG (\d+\.\d+)', file_path)
+    match = re.search(r'Blue\s*IG[\\/\s_-]*([0-9]+(?:\.[0-9]+)*)', file_path, re.IGNORECASE)
     return match.group(1) if match else "Unknown"
 
 def get_bvi_version(file_path):
@@ -282,6 +307,8 @@ def ensure_executable(config_key: str, exe_name: str, prompt_title: str) -> str:
             path = get_vbs4_install_path()
         elif candidate == 'blueig.exe':
             path = get_blueig_install_path()
+        elif candidate == 'vbslauncher.exe':
+            path = get_vbs4_launcher_path()
         else:
             path = find_executable(exe_name)
     else:


### PR DESCRIPTION
## Summary
- handle version numbers in paths with slashes/backslashes for VBS4 and BlueIG
- auto-detect VBS4 launcher by searching near the VBS4 executable

## Testing
- `python3 -m py_compile PythonPorjects/STE_Toolkit.py "PythonPorjects/Gui tezt.py"`


------
https://chatgpt.com/codex/tasks/task_e_68505f4fa0008322a246e5c4f8681e09

## Summary by Sourcery

Enhance version detection by refining regex logic for VBS4 and BlueIG executables and introduce automatic discovery of the VBS4 launcher, integrating it into the toolkit’s executable resolution process.

New Features:
- Add get_vbs4_launcher_path to auto-detect the VBS4 launcher executable from config, neighboring directories, or system PATH

Enhancements:
- Improve version extraction regex for VBS4 and BlueIG to handle varied path separators and naming conventions
- Include vbslauncher.exe in the executable resolution workflow within ensure_executable