### PR TITLE
Improve launcher path detection

### DIFF
--- a/PythonPorjects/STE_Toolkit.py
+++ b/PythonPorjects/STE_Toolkit.py
@@ -32,22 +32,55 @@ SWP_FRAMECHANGED = 0x0020
 #==============================================================================
 
 
+def _find_from_registry(exe_name: str) -> str:
+    """Search common BISim registry keys for the given executable."""
+    sub_roots = [
+        r"SOFTWARE\Bohemia Interactive Simulations",
+        r"SOFTWARE\WOW6432Node\Bohemia Interactive Simulations",
+    ]
+    for root in (winreg.HKEY_CURRENT_USER, winreg.HKEY_LOCAL_MACHINE):
+        for sub in sub_roots:
+            try:
+                base = winreg.OpenKey(root, sub)
+            except FileNotFoundError:
+                continue
+            with base:
+                try:
+                    num_subkeys = winreg.QueryInfoKey(base)[0]
+                    for i in range(num_subkeys):
+                        subkey_name = winreg.EnumKey(base, i)
+                        try:
+                            with winreg.OpenKey(base, subkey_name) as sk:
+                                val, _ = winreg.QueryValueEx(sk, 'InstallLocation')
+                                candidate = os.path.join(val, exe_name)
+                                if os.path.isfile(candidate):
+                                    return candidate
+                        except FileNotFoundError:
+                            pass
+                except OSError:
+                    pass
+    return ''
+
+
 def get_vbs4_install_path() -> str:
-    """Return the saved VBS4 path or try to auto-detect without saving."""
-    path = config['General'].get('vbs4_path', '')
+    """Return the saved VBS4 path or try to auto-detect."""
+    path = config['General'].get('vbs4_path', '').strip()
     if path and os.path.isfile(path):
         return path
 
-    found = find_executable('VBS4.exe')
+    found = find_executable('VBS4.exe') or _find_from_registry('VBS4.exe')
     if found and os.path.isfile(found):
+        config['General']['vbs4_path'] = found
+        with open(CONFIG_PATH, 'w') as f:
+            config.write(f)
         return found
 
     return ''
 
 
 def get_vbs4_launcher_path() -> str:
-    """Return the saved VBS4 launcher or try to find it near the VBS4 install."""
-    path = config['General'].get('vbs4_setup_path', '')
+    """Return the saved VBS4 launcher or try to find it automatically."""
+    path = config['General'].get('vbs4_setup_path', '').strip()
     if path and os.path.isfile(path):
         return path
 
@@ -60,10 +93,16 @@ def get_vbs4_launcher_path() -> str:
         ]
         for cand in candidates:
             if os.path.isfile(cand):
+                config['General']['vbs4_setup_path'] = cand
+                with open(CONFIG_PATH, 'w') as f:
+                    config.write(f)
                 return cand
 
-    found = find_executable('VBSLauncher.exe')
+    found = find_executable('VBSLauncher.exe') or _find_from_registry('VBSLauncher.exe')
     if found and os.path.isfile(found):
+        config['General']['vbs4_setup_path'] = found
+        with open(CONFIG_PATH, 'w') as f:
+            config.write(f)
         return found
 
     return ''
@@ -105,10 +144,13 @@ def find_executable(name, additional_paths=[]):
     elif ext.lower() == '.bat':
         candidates.append(base + '.exe')
 
+    pf     = os.environ.get('ProgramFiles', r'C:\\Program Files')
+    pf86   = os.environ.get('ProgramFiles(x86)', r'C:\\Program Files (x86)')
     possible_paths = [
-        r"C:\BISIM\VBS4",
-        r"C:\Builds\VBS4",
-        r"C:\Builds"
+        r"C:\BISIM",
+        r"C:\Builds",
+        os.path.join(pf,  'Bohemia Interactive Simulations'),
+        os.path.join(pf86,'Bohemia Interactive Simulations'),
     ] + additional_paths
 
     for path in possible_paths:

--- a/PythonPorjects/config.ini
+++ b/PythonPorjects/config.ini
@@ -1,18 +1,18 @@
 [General]
 close_on_launch = True
-default_browser = C:/Users/tifte/AppData/Local/Programs/Opera GX/opera.exe
-vbs4_path = C:\Builds\VBS4\VBS4 25.1 YYMEA_General\VBS4.exe
-blueig_path = C:\Builds\BlueIG\Blue IG 24.2 YYMEA_General\BlueIG.exe
-bvi_manager_path = C:/Program Files/ARES/ARES-dev-release-v0.9.4-c1d3950/ares.manager/ares.manager.exe
-vbs4_setup_path = C:\Builds\VBS4\VBS4 25.1 YYMEA_General\VBSLauncher.exe
-vbs_license_manager_path = C:\Program Files\Bohemia Interactive Simulations\VBS License Manager\VBSLicenseManager.exe
-vbs_map_user = TIFTE
-vbs_map_server = localhost
+default_browser =
+vbs4_path =
+blueig_path =
+bvi_manager_path =
+vbs4_setup_path =
+vbs_license_manager_path =
+vbs_map_user =
+vbs_map_server =
 vbs_map_port = 4080
 fullscreen = True
 
 [Auto-Launch]
 enabled = True
-program_path = C:/Users/tifte/Desktop/Auto-Launch.lnk
+program_path =
 arguments = ""
 


### PR DESCRIPTION
## Summary
- add registry search for installer paths
- auto-detect launcher paths and store them
- broaden search directories in `find_executable`
- remove hard-coded installation paths from example config

## Testing
- `python3 -m py_compile PythonPorjects/STE_Toolkit.py`

------
https://chatgpt.com/codex/tasks/task_e_68518642410883229645ed3a0a7e3739

## Summary by Sourcery

Improve launcher and installer path detection on Windows by adding registry lookups, broadening search directories, and automatically persisting found paths.

Enhancements:
- Add Windows registry lookup for VBS executables in common BISIM registry keys
- Broaden default search paths in find_executable to include Program Files, Program Files (x86), and BISIM directories
- Automatically detect VBS4 and VBSLauncher paths and store them in the configuration file

Documentation:
- Remove hard-coded installation paths from the example config file