### PR TITLE
Add exe version extraction logic

### DIFF
--- a/PythonPorjects/STE_Toolkit.py
+++ b/PythonPorjects/STE_Toolkit.py
@@ -72,19 +72,41 @@ def get_vbs4_launcher_path() -> str:
 # VERSION DISPLAY FUNCTIONS
 #==============================================================================
 
-def get_vbs4_version(file_path):
-    """Extract VBS4 version from the file path."""
+def get_exe_file_version(exe_path: str) -> str:
+    """Return the FileVersion field from an executable, if available."""
+    try:
+        info = win32api.GetFileVersionInfo(exe_path, '\\')
+        ms = info['FileVersionMS']
+        ls = info['FileVersionLS']
+        return f"{ms >> 16}.{ms & 0xFFFF}.{ls >> 16}.{ls & 0xFFFF}"
+    except Exception:
+        return "Unknown"
+
+def get_vbs4_version(file_path: str) -> str:
+    """Extract VBS4 version from the file or its path."""
+    if os.path.isfile(file_path):
+        ver = get_exe_file_version(file_path)
+        if ver != "Unknown":
+            return ver
     # handle paths like ".../VBS4/25.1/VBS4.exe" or "VBS4 25.1" etc.
     match = re.search(r'VBS4[\\/\s_-]*([0-9]+(?:\.[0-9]+)*)', file_path, re.IGNORECASE)
     return match.group(1) if match else "Unknown"
 
-def get_blueig_version(file_path):
-    """Extract BlueIG version from the file path."""
+def get_blueig_version(file_path: str) -> str:
+    """Extract BlueIG version from the file or its path."""
+    if os.path.isfile(file_path):
+        ver = get_exe_file_version(file_path)
+        if ver != "Unknown":
+            return ver
     match = re.search(r'Blue\s*IG[\\/\s_-]*([0-9]+(?:\.[0-9]+)*)', file_path, re.IGNORECASE)
     return match.group(1) if match else "Unknown"
 
-def get_bvi_version(file_path):
-    """Extract BVI (ARES) version from the file path."""
+def get_bvi_version(file_path: str) -> str:
+    """Extract BVI (ARES) version from the file or its path."""
+    if os.path.isfile(file_path):
+        ver = get_exe_file_version(file_path)
+        if ver != "Unknown":
+            return ver
     match = re.search(r'ARES-dev-release-v(\d+\.\d+\.\d+)', file_path)
     return match.group(1) if match else "Unknown"
 

--- a/PythonPorjects/get_exe_version.py
+++ b/PythonPorjects/get_exe_version.py
@@ -1,0 +1,25 @@
+import sys
+import win32api
+
+
+def get_exe_file_version(exe_path: str) -> str:
+    """Return the FileVersion field from an executable."""
+    try:
+        info = win32api.GetFileVersionInfo(exe_path, '\\')
+        ms = info['FileVersionMS']
+        ls = info['FileVersionLS']
+        return f"{ms >> 16}.{ms & 0xFFFF}.{ls >> 16}.{ls & 0xFFFF}"
+    except Exception:
+        return "Unknown"
+
+
+def main() -> None:
+    if len(sys.argv) != 2:
+        print("Usage: python get_exe_version.py <path_to_exe>")
+        sys.exit(1)
+    exe_path = sys.argv[1]
+    print(get_exe_file_version(exe_path))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a helper script `get_exe_version.py` to print the FileVersion of an exe
- update STE_Toolkit version helpers to read the FileVersion from executables if available

## Testing
- `python -m py_compile PythonPorjects/STE_Toolkit.py PythonPorjects/get_exe_version.py`
- `python -m py_compile PythonPorjects/get_exe_version.py`

------
https://chatgpt.com/codex/tasks/task_e_6851aff7e4d48322b4097089f5ae3ca8

## Summary by Sourcery

Add logic to extract FileVersion from executables and integrate it into STE_Toolkit utilities, complemented by a new CLI script for standalone usage.

New Features:
- Add standalone script to print an executable's FileVersion via win32api

Enhancements:
- Update STE_Toolkit version helpers to extract FileVersion from executables when available, falling back to regex path matching