### PR TITLE
Fix Windows paths

### DIFF
--- a/PythonPorjects/Autolaunch_Batchfiles/BVI_Manager.bat
+++ b/PythonPorjects/Autolaunch_Batchfiles/BVI_Manager.bat
@@ -1,5 +1,5 @@
 @echo off
-start "" "C:/Program Files/ARES/ARES-dev-release-v0.9.4-c1d3950/ares.manager/ares.manager.exe"
+start "" "C:\Program Files\ARES\ARES-dev-release-v0.9.4-c1d3950\ares.manager\ares.manager.exe"
 timeout /t 40 /nobreak
-start "" "C:/Program Files/ARES/ARES-dev-release-v0.9.4-c1d3950/ares.manager/ares.manager.exe"
+start "" "C:\Program Files\ARES\ARES-dev-release-v0.9.4-c1d3950\ares.manager\ares.manager.exe"
 exit /b 0

--- a/PythonPorjects/Autolaunch_Batchfiles/for.txt
+++ b/PythonPorjects/Autolaunch_Batchfiles/for.txt
@@ -11,4 +11,4 @@ for
 
 }
 
-file:///C:/BISIM/VBS4/docs/SQF_Resources/VBS2PluginFileAccess.html
+file:///C:\BISIM\VBS4\docs\SQF_Resources\VBS2PluginFileAccess.html

--- a/PythonPorjects/config.ini
+++ b/PythonPorjects/config.ini
@@ -1,11 +1,11 @@
 [General]
 close_on_launch = True
-default_browser = C:/Users/tifte/AppData/Local/Programs/Opera GX/opera.exe
-vbs4_path = C:/Builds/VBS4\VBS4 25.1 YYMEA_General/VBS4.exe
-blueig_path = C:/Builds/BlueIG/Blue IG 24.2 YYMEA_General/BlueIG.exe
-bvi_manager_path = C:/Program Files/ARES/ARES-dev-release-v0.9.4-c1d3950/ares.manager/ares.manager.exe
-vbs4_setup_path = C:/Builds/VBS4/VBS4 25.1 YYMEA_General/VBSLauncher.exe
-vbs_license_manager_path = C:/Program Files/Bohemia Interactive Simulations/VBS License Manager/VBSLicenseManager.exe
+default_browser = C:\Users\tifte\AppData\Local\Programs\Opera GX\opera.exe
+vbs4_path = C:\Builds\VBS4\VBS4 25.1 YYMEA_General\VBS4.exe
+blueig_path = C:\Builds\BlueIG\Blue IG 24.2 YYMEA_General\BlueIG.exe
+bvi_manager_path = C:\Program Files\ARES\ARES-dev-release-v0.9.4-c1d3950\ares.manager\ares.manager.exe
+vbs4_setup_path = C:\Builds\VBS4\VBS4 25.1 YYMEA_General\VBSLauncher.exe
+vbs_license_manager_path = C:\Program Files\Bohemia Interactive Simulations\VBS License Manager\VBSLicenseManager.exe
 vbs_map_user = TIFTE
 vbs_map_server = localhost
 vbs_map_port = 4080
@@ -13,6 +13,6 @@ fullscreen = True
 
 [Auto-Launch]
 enabled = True
-program_path = C:/Users/tifte/Desktop/Auto-Launch.lnk
+program_path = C:\Users\tifte\Desktop\Auto-Launch.lnk
 arguments = ""
 


### PR DESCRIPTION
## Summary
- use Windows-style backslashes in config and batch files

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852dafe82808322a6c68239d88ddb77