### PR TITLE
Fix path separator handling

### DIFF
--- a/PythonPorjects/STE_Toolkit.py
+++ b/PythonPorjects/STE_Toolkit.py
@@ -131,9 +131,9 @@ def find_executable(name, additional_paths=[]):
         candidates.append(base + '.exe')
 
     possible_paths = [
-        r"C:/BISIM\VBS4",
-        r"C:/Builds\VBS4",
-        r"C:/Builds"
+        r"C:\BISIM\VBS4",
+        r"C:\Builds\VBS4",
+        r"C:\Builds"
     ] + additional_paths
 
     for path in possible_paths:
@@ -141,7 +141,7 @@ def find_executable(name, additional_paths=[]):
             for root, dirs, files in os.walk(path):
                 for cand in candidates:
                     if cand in files:
-                        return os.path.join(root, cand)
+                        return os.path.normpath(os.path.join(root, cand))
     return None
 
 #==============================================================================
@@ -755,6 +755,7 @@ def set_vbs4_install_path():
         filetypes=[("Executable Files", "*.exe")]
     )
     if path and os.path.exists(path):
+        path = os.path.normpath(path)
         config['General']['vbs4_path'] = path
         with open(CONFIG_PATH, 'w') as f:
             config.write(f)


### PR DESCRIPTION
## Summary
- standardize VBS4 search paths
- normalize path when saving VBS4 location

## Testing
- `pre-commit` *(fails: no config)*

------
https://chatgpt.com/codex/tasks/task_e_6859a44500388322b544f21b4eba81af

## Summary by Sourcery

Normalize Windows path separators and ensure consistent path handling for VBS4 executable discovery and configuration

Bug Fixes:
- Use correct backslashes in default VBS4 search paths
- Normalize returned executable paths from find_executable
- Normalize selected VBS4 install path before saving to configuration