### PR TITLE
Update search paths for VBS4 detection

### DIFF
--- a/PythonPorjects/STE_Toolkit.py
+++ b/PythonPorjects/STE_Toolkit.py
@@ -50,7 +50,8 @@ def get_vbs4_install_path():
     possible_paths = [
         r"C:\BISIM\VBS4",
         r"C:\Builds\VBS4",
-        r"C:\Builds"
+        r"C:\Builds",
+        r"C:\Bohemia Interactive Simulations"
     ]
     for base_path in possible_paths:
         if os.path.isdir(base_path):
@@ -82,7 +83,8 @@ def get_vbs4_launcher_path():
     possible_paths = [
         r"C:\BISIM\VBS4",
         r"C:\Builds\VBS4",
-        r"C:\Builds"
+        r"C:\Builds",
+        r"C:\Bohemia Interactive Simulations"
     ]
 
     for base_path in possible_paths:
@@ -179,7 +181,8 @@ def find_executable(name, additional_paths=[]):
     possible_paths = [
         r"C:\BISIM\VBS4",
         r"C:\Builds\VBS4",
-        r"C:\Builds"
+        r"C:\Builds",
+        r"C:\Bohemia Interactive Simulations"
     ] + additional_paths
 
     best_path = None


### PR DESCRIPTION
## Summary
- add `C:\Bohemia Interactive Simulations` to the default search paths so VBS4 can be auto-detected on machines installed in that location

## Testing
- `python3 -m py_compile PythonPorjects/STE_Toolkit.py`

------
https://chatgpt.com/codex/tasks/task_e_68645fa9daac832294eae40765b075e7