### PR TITLE
Add recursive image folder selection

### DIFF
--- a/PythonPorjects/STE_Toolkit.py
+++ b/PythonPorjects/STE_Toolkit.py
@@ -336,6 +336,17 @@ exit /b 0
     return BVI_BAT
 
 
+def get_image_folders_recursively(base_folder):
+    """Return all subfolders within *base_folder* that contain image files."""
+    image_folders = []
+    for root, dirs, files in os.walk(base_folder):
+        if any(file.lower().endswith(
+            (".jpg", ".jpeg", ".png", ".tif", ".tiff")) for file in files
+        ):
+            image_folders.append(root)
+    return image_folders
+
+
 
 def create_app_button(parent, app_name, get_path_func, launch_func, set_path_func):
     frame = tk.Frame(parent, bg="#333333")
@@ -1676,13 +1687,20 @@ class VBS4Panel(tk.Frame):
 
     
         def add_folder():
-            path = simpledialog.askstring("Network Path", "Enter network folder path (leave blank to browse):")
+            path = simpledialog.askstring(
+                "Network Path",
+                "Enter network folder path (leave blank to browse):"
+            )
             if path and os.path.exists(path):
-                folders.append(path)
+                found = get_image_folders_recursively(path)
+                folders.extend(found)
             else:
-                selected = filedialog.askdirectory(title="Select Drone Imagery Folder")
+                selected = filedialog.askdirectory(
+                    title="Select DCIM or base imagery folder"
+                )
                 if selected:
-                    folders.append(selected)
+                    found = get_image_folders_recursively(selected)
+                    folders.extend(found)
         
             # Update the listbox
             folder_listbox.delete(0, tk.END)


### PR DESCRIPTION
## Summary
- introduce `get_image_folders_recursively` helper
- update `select_imagery` to detect imagery folders under a selected base folder

## Testing
- `python3 -m py_compile PythonPorjects/STE_Toolkit.py`

------
https://chatgpt.com/codex/tasks/task_e_686c2379911483228ea137878cf32caf

## Summary by Sourcery

Add a helper to collect all image-containing subfolders under a given directory and wire it into the imagery selection workflow to automatically detect and list nested image folders.

New Features:
- Add get_image_folders_recursively helper to find all subdirectories containing image files

Enhancements:
- Integrate recursive image folder detection into imagery selection for both typed paths and browsed directories
- Update imagery folder browsing dialog title to clarify DCIM or base imagery folder selection