### PR TITLE
Add external fuser configuration

### DIFF
--- a/PythonPorjects/config.ini
+++ b/PythonPorjects/config.ini
@@ -16,3 +16,8 @@ enabled = True
 program_path = C:/Users/tifte/Desktop/Auto-Launch.lnk
 arguments = ""
 
+
+[Fusers]
+config_path = fuser_config.json
+local_fuser_exe = C:\\Program Files\\Skyline\\PhotoMesh\\Fuser\\Fuser.exe
+remote_fuser_exe = C:\\Program Files\\Skyline\\PhotoMesh Fuser\\PhotoMeshFuser.exe

--- a/PythonPorjects/fuser_config.json
+++ b/PythonPorjects/fuser_config.json
@@ -1,0 +1,11 @@
+{
+  "fusers": {
+    "192.168.1.100": [
+      {"name": "Fuser1", "shared_path": "\\\\192.168.1.100\\SharedMeshDrive\\WorkingFuser"},
+      {"name": "Fuser2", "shared_path": "\\\\192.168.1.100\\SharedMeshDrive\\WorkingFuser"}
+    ],
+    "192.168.1.101": [
+      {"name": "Fuser1", "shared_path": "\\\\192.168.1.101\\SharedMeshDrive\\WorkingFuser"}
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- load fuser details from a new `fuser_config.json` file
- store fuser paths in `config.ini`
- update `STE_Toolkit.py` to use configuration file and local/remote fuser paths

## Testing
- `python -m py_compile PythonPorjects/STE_Toolkit.py`
- `python -m py_compile PythonPorjects/*.py`

------
https://chatgpt.com/codex/tasks/task_e_686d58113adc832296738fc764b8a757

## Summary by Sourcery

Introduce external Fuser configuration via JSON and make Fuser executable paths configurable through config.ini

New Features:
- Load per-IP Fuser definitions from fuser_config.json to support multiple remote Fuser instances
- Add [Fusers] section in config.ini to specify local and remote Fuser executable paths

Enhancements:
- Refactor launch_fusers to parse the external JSON config, iterate configured Fusers, and use the configurable executables
- Automatically initialize default [Fusers] settings in config.ini when the section is missing