### PR TITLE
Fix initialization of focusable_buttons

### DIFF
--- a/PythonPorjects/STE_Toolkit.py
+++ b/PythonPorjects/STE_Toolkit.py
@@ -993,6 +993,9 @@ class MainApp(tk.Tk):
          # Prevent window resizing
         self.resizable(False, False)
 
+        # List of buttons that can receive keyboard focus
+        self.focusable_buttons = []
+
         self.fullscreen = config.getboolean('General', 'fullscreen', fallback=False)
 
         # screen dims


### PR DESCRIPTION
## Summary
- avoid AttributeError by initializing `focusable_buttons` before use

## Testing
- `python3 -m py_compile PythonPorjects/STE_Toolkit.py`

------
https://chatgpt.com/codex/tasks/task_e_686da34ecac48322969c001a3f25852c

## Summary by Sourcery

Bug Fixes:
- Initialize focusable_buttons list before use to prevent AttributeError