### PR TITLE
Fix nav tooltip concatenation error

### DIFF
--- a/PythonPorjects/STE_Toolkit.py
+++ b/PythonPorjects/STE_Toolkit.py
@@ -1068,7 +1068,7 @@ class MainApp(tk.Tk):
                             width=12,
                             command=lambda k=key: self.show(k))
             btn.pack(pady=5, padx=5)
-            btn.bind("<Enter>", lambda e, l=label: nav_tip.show("Go to " . l, e.x_root+10, e.y_root+10))
+            btn.bind("<Enter>", lambda e, l=label: nav_tip.show(f"Go to {l}", e.x_root+10, e.y_root+10))
             btn.bind("<Leave>", lambda e: nav_tip.hide())
             self.focusable_buttons.append(btn)
 


### PR DESCRIPTION
## Summary
- fix tooltip string concatenation when hovering nav buttons

## Testing
- `python3 -m py_compile PythonPorjects/STE_Toolkit.py`


------
https://chatgpt.com/codex/tasks/task_e_686da8e238508322906e2158987ddfc3

## Summary by Sourcery

Bug Fixes:
- Use f-string for tooltip text to correctly display "Go to <label>" on nav button hover