### PR TITLE
Fix imagery selection window always on top

### DIFF
--- a/PythonPorjects/STE_Toolkit.py
+++ b/PythonPorjects/STE_Toolkit.py
@@ -1756,10 +1756,15 @@ class VBS4Panel(tk.Frame):
     
         folders = []
     
-        # Create a new top-level window for folder selection
+        # Create a new top-level window for folder selection.  Make it modal
+        # and keep it above the main application so it does not get lost
+        # behind the main window while the user is picking folders.
         folder_window = tk.Toplevel(self)
         folder_window.title("Select Imagery Folders")
         folder_window.geometry("500x300")
+        folder_window.transient(self)  # associate with parent
+        folder_window.grab_set()       # make modal
+        folder_window.attributes("-topmost", True)
     
         # Create a listbox to display selected folders
         folder_listbox = tk.Listbox(folder_window, width=70, height=10)


### PR DESCRIPTION
## Summary
- make the imagery folder selection dialog a modal top-level window

## Testing
- `python -m py_compile PythonPorjects/STE_Toolkit.py`


------
https://chatgpt.com/codex/tasks/task_e_686daec7d9708322bf336b287a77d8f0

## Summary by Sourcery

Fix the imagery folder selection dialog to be modal, associated with the parent window, and always stay on top.

Bug Fixes:
- Ensure imagery selection window is transient to the main app and grabs focus as a modal dialog
- Keep the imagery selection window on top using the "-topmost" attribute