### PR TITLE
Enable Enter key selection in keyboard navigation

### DIFF
--- a/PythonPorjects/STE_Toolkit.py
+++ b/PythonPorjects/STE_Toolkit.py
@@ -1106,6 +1106,7 @@ class MainApp(tk.Tk):
             self.bind(key, self.focus_next)
         for key in ("<Left>", "<Up>"):
             self.bind(key, self.focus_prev)
+        self.bind("<Return>", self.activate_current)
         self.update_navigation()
 
     def toggle_fullscreen(self):
@@ -1203,6 +1204,16 @@ class MainApp(tk.Tk):
             return
         self.focus_index = (self.focus_index - 1) % len(self.focusable_buttons)
         self.highlight_current()
+
+    def activate_current(self, event=None):
+        """Invoke the currently focused button."""
+        if not self.focusable_buttons:
+            return
+        btn = self.focusable_buttons[self.focus_index]
+        try:
+            btn.invoke()
+        except Exception:
+            pass
 
     def create_tutorial_button(self, parent):
         """


### PR DESCRIPTION
## Summary
- allow MainApp to activate the focused button via the Enter key
- add new `activate_current` method to invoke the currently selected button

## Testing
- `python -m py_compile PythonPorjects/STE_Toolkit.py`


------
https://chatgpt.com/codex/tasks/task_e_686def087fd48322846965ef656dbe1f

## Summary by Sourcery

Bind the Enter key to trigger invocation of the currently focused button in MainApp keyboard navigation

New Features:
- Enable Enter key to activate focused button in keyboard navigation

Enhancements:
- Add activate_current method to invoke the currently selected button