### PR TITLE
Fix fuser launch path and support batch files

### DIFF
--- a/PythonPorjects/STE_Toolkit.py
+++ b/PythonPorjects/STE_Toolkit.py
@@ -1842,7 +1842,10 @@ class VBS4Panel(tk.Frame):
 
     def launch_fusers(self, ip_list):
         config_file = config['Fusers'].get('config_path', 'fuser_config.json')
-        fuser_exe = r'C:\Program Files\Skyline\PhotoMesh\Fuser\PhotoMeshFuser.exe'
+        fuser_exe = config['Fusers'].get(
+            'local_fuser_exe',
+            r'C:\\Program Files\\Skyline\\PhotoMesh\\Fuser\\PhotoMeshFuser.exe'
+        )
 
         def load_fuser_config(file_path):
             full_path = os.path.join(BASE_DIR, file_path) if not os.path.isabs(file_path) else file_path
@@ -1864,7 +1867,13 @@ class VBS4Panel(tk.Frame):
             for fuser in fusers:
                 name = fuser.get('name')
                 path = fuser.get('shared_path')
-                cmd = f'start "" "{fuser_exe}" "{name}" "{path}" 0 true'
+
+                bat_path = rf'\\{ip}\\C$\\Program Files\\Skyline\\PhotoMesh\\Fuser\\{name}.bat'
+                if os.path.isfile(bat_path):
+                    cmd = f'start "" "{bat_path}"'
+                else:
+                    cmd = f'start "" "{fuser_exe}" "{name}" "{path}" 0 true'
+
                 try:
                     subprocess.run(cmd, shell=True, check=True)
                     self.log_message(f"Launched {name} at {path}")
@@ -1874,7 +1883,13 @@ class VBS4Panel(tk.Frame):
         # Launch local fuser
         local_fuser_name = "LocalFuser"  # You may want to make this configurable
         local_fuser_path = r"\\localhost\SharedMeshDrive\WorkingFuser"  # Adjust as needed
-        local_cmd = f'start "" "{fuser_exe}" "{local_fuser_name}" "{local_fuser_path}" 0 true'
+
+        local_bat = rf'C:\\Program Files\\Skyline\\PhotoMesh\\Fuser\\{local_fuser_name}.bat'
+        if os.path.isfile(local_bat):
+            local_cmd = f'start "" "{local_bat}"'
+        else:
+            local_cmd = f'start "" "{fuser_exe}" "{local_fuser_name}" "{local_fuser_path}" 0 true'
+
         try:
             subprocess.run(local_cmd, shell=True, check=True)
             self.log_message("Local fuser launched.")

--- a/PythonPorjects/config.ini
+++ b/PythonPorjects/config.ini
@@ -18,6 +18,6 @@ arguments = ""
 
 [Fusers]
 config_path = fuser_config.json
-local_fuser_exe = C:\\Program Files\\Skyline\\PhotoMesh\\Fuser\\Fuser.exe
-remote_fuser_exe = C:\\Program Files\\Skyline\\PhotoMesh Fuser\\PhotoMeshFuser.exe
+local_fuser_exe = C:\\Program Files\\Skyline\\PhotoMesh\\Fuser\\PhotoMeshFuser.exe
+remote_fuser_exe = C:\\Program Files\\Skyline\\PhotoMesh\\Fuser\\PhotoMeshFuser.exe
 

--- a/PythonPorjects/fuser_config.json
+++ b/PythonPorjects/fuser_config.json
@@ -1,11 +1,16 @@
 {
   "fusers": {
     "192.168.1.100": [
-      {"name": "RyanFuser3", "shared_path": "\\\\192.168.1.100\\SharedMeshDrive\\WorkingFuser"},
-      {"name": "RyanFuser2", "shared_path": "\\\\192.168.1.100\\SharedMeshDrive\\WorkingFuser"}
+      {
+        "name": "RyanFuser1",
+        "shared_path": "\\\\RyansWorkPC2\\SharedMeshDrive\\WorkingFuser"
+      }
     ],
-    "192.168.1.101": [
-      {"name": "RyanFuser1", "shared_path": "\\\\192.168.1.101\\SharedMeshDrive\\WorkingFuser"}
+    "localhost": [
+      {
+        "name": "LocalFuser",
+        "shared_path": "\\\\localhost\\SharedMeshDrive\\WorkingFuser"
+      }
     ]
   }
 }


### PR DESCRIPTION
## Summary
- correct fuser executable paths in `config.ini`
- update default fuser configuration
- improve `launch_fusers` to optionally use batch files and configurable exe path

## Testing
- `python3 -m py_compile PythonPorjects/STE_Toolkit.py`

------
https://chatgpt.com/codex/tasks/task_e_686e6cebee248322a2138c7f9a1b75c8

## Summary by Sourcery

Update fuser launch functionality to read executable paths from configuration, correct default paths, and support optional batch file execution for both remote and local fusers.

Bug Fixes:
- Correct default fuser executable paths in config.ini

Enhancements:
- Allow configurable local fuser executable path via config
- Detect and launch batch files for remote and local fusers if present
- Improve launch_fusers logic to fallback to executable launch when no batch file exists