### PR TITLE
Implement host-aware fuser paths

### DIFF
--- a/PythonPorjects/STE_Toolkit.py
+++ b/PythonPorjects/STE_Toolkit.py
@@ -294,8 +294,17 @@ if 'Fusers' not in config:
     config['Fusers'] = {
         'config_path': 'fuser_config.json',
         'local_fuser_exe': r'C:\\Program Files\\Skyline\\PhotoMesh\\Fuser\\Fuser.exe',
-        'remote_fuser_exe': r'C:\\Program Files\\Skyline\\PhotoMesh Fuser\\PhotoMeshFuser.exe'
+        'remote_fuser_exe': r'C:\\Program Files\\Skyline\\PhotoMesh Fuser\\PhotoMeshFuser.exe',
+        'fuser_computer': 'False',
+        'local_fuser_bat': r'C:\\Program Files\\Skyline\\PhotoMesh\\Fuser\\start_fusers.bat'
     }
+    with open(CONFIG_PATH, 'w') as f:
+        config.write(f)
+elif 'fuser_computer' not in config['Fusers'] or 'local_fuser_bat' not in config['Fusers']:
+    if 'fuser_computer' not in config['Fusers']:
+        config['Fusers']['fuser_computer'] = 'False'
+    if 'local_fuser_bat' not in config['Fusers']:
+        config['Fusers']['local_fuser_bat'] = r'C:\\Program Files\\Skyline\\PhotoMesh\\Fuser\\start_fusers.bat'
     with open(CONFIG_PATH, 'w') as f:
         config.write(f)
 
@@ -1478,6 +1487,7 @@ class VBS4Panel(tk.Frame):
         )
         self.terrain_button.bind("<Leave>", self.hide_tooltip)
         self.create_hidden_terrain_buttons()
+        self.update_fuser_state()
 
         # External Map button
         tk.Button(
@@ -1745,6 +1755,20 @@ class VBS4Panel(tk.Frame):
         else:
             self.vbs4_launcher_button.config(state="disabled", bg="#888888")
 
+    def update_fuser_state(self):
+        is_fuser = config['Fusers'].getboolean('fuser_computer', fallback=False)
+        tip = "This pc is being used as a fuser" if is_fuser else "Show or hide terrain tools"
+        state = "disabled" if is_fuser else "normal"
+        bg = "#888888" if is_fuser else "#444"
+
+        self.terrain_button.config(state=state, bg=bg, text="One-Click Terrain Converter")
+        self.terrain_button.bind("<Enter>", lambda e: self.show_tooltip(e, tip))
+        self.terrain_button.bind("<Leave>", self.hide_tooltip)
+
+        for btn in self.hidden_buttons:
+            btn.pack_forget()
+            btn.config(state=state)
+
     def set_file_location(self, app_name, config_key, button):
         path = filedialog.askopenfilename(
             title=f"Select {app_name} Executable",
@@ -1895,6 +1919,11 @@ class VBS4Panel(tk.Frame):
 
         fuser_settings, default_path = load_fuser_config(config_file)
 
+        # Replace 'localhost' entries with this machine's hostname
+        hostname = os.environ.get('COMPUTERNAME', socket.gethostname())
+        if 'localhost' in fuser_settings:
+            fuser_settings.setdefault(hostname, fuser_settings.pop('localhost'))
+
         # Auto-discover fuser directories if a shared path is provided
         discovered = discover_fusers_from_shared_path(default_path)
         for ip, info in discovered.items():
@@ -1941,21 +1970,59 @@ class VBS4Panel(tk.Frame):
                 except subprocess.CalledProcessError as e:
                     self.log_message(f"Failed to launch {name} on {ip}: {e}")
 
-        # Launch local fuser
-        local_fuser_name = "LocalFuser"  # You may want to make this configurable
-        local_fuser_path = default_path or r"\\localhost\SharedMeshDrive\WorkingFuser"  # Adjust as needed
+        # Launch local fusers on this machine
+        self.launch_local_fuser(default_path)
 
-        local_bat = rf'C:\\Program Files\\Skyline\\PhotoMesh\\Fuser\\{local_fuser_name}.bat'
-        if os.path.isfile(local_bat):
-            local_cmd = f'start "" "{local_bat}"'
+    def launch_local_fuser(self, shared_path=None):
+        config_file = config['Fusers'].get('config_path', 'fuser_config.json')
+        fuser_exe = config['Fusers'].get(
+            'local_fuser_exe',
+            r'C:\\Program Files\\Skyline\\PhotoMesh\\Fuser\\PhotoMeshFuser.exe'
+        )
+        bat_file = config['Fusers'].get('local_fuser_bat', '')
+
+        if bat_file and os.path.isfile(bat_file):
+            try:
+                subprocess.Popen(f'start "" "{bat_file}"', shell=True)
+                self.log_message("Launched local fusers from batch file.")
+            except Exception as e:
+                self.log_message(f"Failed to run fuser batch: {e}")
+            return
+
+        def load_fuser_config(file_path):
+            full_path = os.path.join(BASE_DIR, file_path) if not os.path.isabs(file_path) else file_path
+            try:
+                with open(full_path, 'r') as f:
+                    data = json.load(f)
+                    return data.get('shared_path')
+            except Exception as e:
+                self.log_message(f"Failed to load fuser config: {e}")
+                return None
+
+        default_path = shared_path
+        if default_path is None:
+            default_path = load_fuser_config(config_file)
+
+        hostname = os.environ.get('COMPUTERNAME', socket.gethostname())
+
+        if not default_path:
+            fuser_path = rf'\\{hostname}\\SharedMeshDrive\\WorkingFuser'
         else:
-            local_cmd = f'start "" "{fuser_exe}" "{local_fuser_name}" "{local_fuser_path}" 0 true'
+            fuser_path = default_path.replace('\\\\localhost', rf'\\{hostname}')
 
-        try:
-            subprocess.run(local_cmd, shell=True, check=True)
-            self.log_message("Local fuser launched.")
-        except subprocess.CalledProcessError as e:
-            self.log_message(f"Failed to start local fuser: {e}")
+        for idx in range(1, 4):
+            name = f"LocalFuser{idx}"
+            bat = rf'C:\\Program Files\\Skyline\\PhotoMesh\\Fuser\\{name}.bat'
+            if os.path.isfile(bat):
+                cmd = f'start "" "{bat}"'
+            else:
+                cmd = f'start "" "{fuser_exe}" "{name}" "{fuser_path}" 0 true'
+
+            try:
+                subprocess.run(cmd, shell=True, check=True)
+                self.log_message(f"Launched {name}.")
+            except subprocess.CalledProcessError as e:
+                self.log_message(f"Failed to start {name}: {e}")
 
     def create_mesh(self):
         if not hasattr(self, 'image_folder_paths') or not self.image_folder_paths:
@@ -2216,6 +2283,27 @@ class SettingsPanel(tk.Frame):
                        text="Close on Software Launch?",
                        variable=self.close_var,
                        command=_on_close_toggle,
+                       font=("Helvetica",20),
+                       bg="#444444", fg="white",
+                       selectcolor="#444444",
+                       indicatoron=True,
+                       width=30, pady=5) \
+          .pack(pady=8)
+
+        self.fuser_var = tk.BooleanVar(value=config['Fusers'].getboolean('fuser_computer', False))
+
+        def _on_fuser_toggle():
+            config['Fusers']['fuser_computer'] = str(self.fuser_var.get())
+            with open(CONFIG_PATH, 'w') as f:
+                config.write(f)
+            self.controller.panels['VBS4'].update_fuser_state()
+            if self.fuser_var.get():
+                run_in_thread(self.controller.panels['VBS4'].launch_local_fuser)
+
+        tk.Checkbutton(self,
+                       text="Fuser Computer",
+                       variable=self.fuser_var,
+                       command=_on_fuser_toggle,
                        font=("Helvetica",20),
                        bg="#444444", fg="white",
                        selectcolor="#444444",
@@ -2637,4 +2725,8 @@ def start_command_server(port: int = 9100) -> None:
 
 if __name__ == "__main__":
     start_command_server()
-    MainApp().mainloop()
+    app = MainApp()
+    if config['Fusers'].getboolean('fuser_computer', False):
+        run_in_thread(app.panels['VBS4'].launch_local_fuser)
+        app.panels['VBS4'].update_fuser_state()
+    app.mainloop()

--- a/PythonPorjects/config.ini
+++ b/PythonPorjects/config.ini
@@ -20,4 +20,6 @@ arguments = ""
 config_path = fuser_config.json
 local_fuser_exe = C:\\Program Files\\Skyline\\PhotoMesh\\Fuser\\PhotoMeshFuser.exe
 remote_fuser_exe = C:\\Program Files\\Skyline\\PhotoMesh\\Fuser\\PhotoMeshFuser.exe
+fuser_computer = False
+local_fuser_bat = C:\\Program Files\\Skyline\\PhotoMesh\\Fuser\\start_fusers.bat
 


### PR DESCRIPTION
## Summary
- replace `localhost` entries in fuser config with this machine's hostname when launching fusers
- choose a UNC path using the local hostname when starting local fusers

## Testing
- `python -m py_compile STE_Toolkit.py`


------
https://chatgpt.com/codex/tasks/task_e_686e892b9fb88322b78c8af454cae457

## Summary by Sourcery

Implement host-aware fuser paths by replacing "localhost" with the machine hostname in UNC paths, adding a fuser_computer flag and UI toggle to designate the host as a fuser, auto-launching local fuser instances on startup, and disabling terrain tools when running as a fuser.

New Features:
- Add fuser_computer config flag and corresponding UI checkbox to mark the current machine as a fuser
- Auto-launch local fuser instances on startup via configurable batch file or direct executable commands
- Replace "localhost" entries in shared fuser paths with the actual machine hostname for UNC paths

Enhancements:
- Refactor local fuser launch logic into a standalone launch_local_fuser method
- Disable terrain conversion tools and update tooltips dynamically when acting as a fuser
- Automatically populate missing Fusers config keys (fuser_computer, local_fuser_bat) on load to maintain backward compatibility

Chores:
- Update config.ini defaults with new fuser_computer and local_fuser_bat settings