### PR TITLE
Allow configuring main fuser PC

### DIFF
--- a/PythonPorjects/config.ini
+++ b/PythonPorjects/config.ini
@@ -21,4 +21,5 @@ config_path = fuser_config.json
 local_fuser_exe = C:\\Program Files\\Skyline\\PhotoMesh\\Fuser\\PhotoMeshFuser.exe
 remote_fuser_exe = C:\\Program Files\\Skyline\\PhotoMesh\\Fuser\\PhotoMeshFuser.exe
 fuser_computer = False
+working_folder_host = 
 


### PR DESCRIPTION
## Summary
- add `working_folder_host` setting for fuser configuration
- prompt for host name when enabling "Fuser Computer"
- update fuser shared path logic to use configured host
- persist host updates in config and sample config.ini

## Testing
- `python -m py_compile PythonPorjects/STE_Toolkit.py`
- `python -m py_compile PythonPorjects/*.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68750b2579c4832290448e087af735a8

## Summary by Sourcery

Enable explicit configuration of the main Fuser PC by introducing a working_folder_host setting, prompting users for the host when toggling the Fuser Computer option, and updating shared path resolution to use the configured host

New Features:
- Add working_folder_host setting to configure the main Fuser PC
- Prompt for host name when enabling the Fuser Computer option

Enhancements:
- Update shared fuser path logic to prioritize the configured host and fall back to UNC-derived host if unset
- Persist the working_folder_host value in config on load and after updates

Documentation:
- Add working_folder_host entry to the sample config.ini