### PR TITLE
Add custom icon support

### DIFF
--- a/PythonPorjects/Gui tezt.py
+++ b/PythonPorjects/Gui tezt.py
@@ -3,6 +3,8 @@ from tkinter import messagebox
 import subprocess
 import os
 
+ICON_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)), "icon.ico")
+
 # Paths to the application executables
 bypass_launcher_path = r"C:\Bohemia Interactive Simulations\VBS4 24.1 YYMEA_General\VBS4.exe" 
 regular_launcher_path = r"C:\Bohemia Interactive Simulations\VBS4 24.1 YYMEA_General\VBSLauncher.exe"  # Regular launcher path
@@ -35,6 +37,10 @@ def exit_application():
 
 # Create the main GUI window
 root = tk.Tk()
+if os.path.exists(ICON_PATH):
+    root.iconbitmap(ICON_PATH)
+else:
+    print(f"Warning: Icon file not found at {ICON_PATH}")
 root.title("VBS4 Custom Launcher")
 root.geometry("400x300")  # Set the window size
 

--- a/PythonPorjects/STE_Toolkit.py
+++ b/PythonPorjects/STE_Toolkit.py
@@ -255,8 +255,17 @@ def find_executable(name, additional_paths=[]):
 
 BASE_DIR    = os.path.dirname(os.path.abspath(__file__))
 CONFIG_PATH = os.path.join(BASE_DIR, 'config.ini')
+ICON_PATH   = os.path.join(BASE_DIR, 'icon.ico')
+
 config      = configparser.ConfigParser()
 config.read(CONFIG_PATH)
+
+def apply_app_icon(window):
+    """Apply the application icon to a Tk window if the icon file exists."""
+    if os.path.exists(ICON_PATH):
+        window.iconbitmap(ICON_PATH)
+    else:
+        print(f"Warning: Icon file not found at {ICON_PATH}")
 
 if 'General' not in config:
     config['General'] = {}
@@ -1063,6 +1072,7 @@ def make_borderless(hwnd):
 def prompt_hostname(parent, initial=""):
     """Show a themed prompt for entering the main PC name."""
     top = tk.Toplevel(parent)
+    apply_app_icon(top)
     top.title("Main PC Name")
     top.resizable(False, False)
     top.geometry("801x506")
@@ -1112,6 +1122,7 @@ def prompt_hostname(parent, initial=""):
 class MainApp(tk.Tk):
     def __init__(self):
         super().__init__()
+        apply_app_icon(self)
         self.title("STE Mission Planning Toolkit")
          # Prevent window resizing
         self.resizable(False, False)
@@ -1895,6 +1906,7 @@ class VBS4Panel(tk.Frame):
         # and keep it above the main application so it does not get lost
         # behind the main window while the user is picking folders.
         folder_window = tk.Toplevel(self)
+        apply_app_icon(folder_window)
         folder_window.title("Select Imagery Folders")
         folder_window.geometry("500x300")
         folder_window.transient(self)  # associate with parent


### PR DESCRIPTION
## Summary
- support icon in `STE_Toolkit.py`
- set the icon in `Gui tezt.py`

## Testing
- `python -m py_compile PythonPorjects/STE_Toolkit.py PythonPorjects/Gui\ tezt.py`


------
https://chatgpt.com/codex/tasks/task_e_6877f32a4930832280b7fb7a44655bf0

## Summary by Sourcery

Add support for loading and applying a custom icon.ico file to Tkinter application windows in both STE_Toolkit and Gui tezt, with warnings if the icon file is missing

New Features:
- Introduce ICON_PATH constant and apply_app_icon helper to set window icons in STE_Toolkit
- Load and apply icon.ico to the main GUI window in Gui tezt with a fallback warning if missing