### PR TITLE
Add manual post-processing workflow

### DIFF
--- a/PythonPorjects/STE_Toolkit.py
+++ b/PythonPorjects/STE_Toolkit.py
@@ -4,6 +4,8 @@ from tkinter import filedialog, messagebox
 from PIL import Image, ImageTk
 import os
 import subprocess
+import shutil
+from datetime import datetime
 import webbrowser
 import urllib.request
 import configparser
@@ -266,6 +268,75 @@ def find_executable(name, additional_paths=[]):
                             best_path = os.path.normpath(full_path)
 
     return best_path
+
+# ---------------------------------------------------------------------------
+# Reality Mesh post-processing helpers
+# ---------------------------------------------------------------------------
+
+def load_system_settings(path: str) -> dict:
+    settings = {}
+    if os.path.isfile(path):
+        with open(path, 'r', encoding='utf-8') as f:
+            for line in f:
+                line = line.strip()
+                if not line or line.startswith('#') or '=' not in line:
+                    continue
+                key, value = line.split('=', 1)
+                settings[key.strip()] = value.strip()
+    return settings
+
+
+def wait_for_file(path: str, poll_interval: float = 5.0) -> None:
+    while not os.path.exists(path):
+        time.sleep(poll_interval)
+
+
+def create_project_folder(build_dir: str, project_name: str) -> tuple[str, str]:
+    dt = datetime.now().strftime('%Y%m%d_%H%M%S')
+    proj_folder = os.path.join(build_dir, f"{project_name}_{dt}")
+    os.makedirs(proj_folder, exist_ok=True)
+    data_folder = os.path.join(proj_folder, 'Data')
+    os.makedirs(data_folder, exist_ok=True)
+    return proj_folder, data_folder
+
+
+def copy_obj(build_dir: str, data_folder: str) -> None:
+    src = os.path.join(build_dir, 'OBJ')
+    dst = os.path.join(data_folder, 'OBJ')
+    if os.path.isdir(src):
+        if os.path.exists(dst):
+            shutil.rmtree(dst)
+        shutil.copytree(src, dst)
+
+
+def write_project_settings(settings_path: str, data: dict, data_folder: str) -> None:
+    with open(settings_path, 'w', encoding='utf-8') as f:
+        project_name = data.get('project_name', 'project')
+        f.write(f"project_name={project_name}\n")
+        f.write(f"source_Directory={data_folder}\n")
+        for k, v in data.items():
+            if k == 'project_name':
+                continue
+            f.write(f"{k}={v}\n")
+
+
+def run_processor(ps_script: str, settings_path: str, log_func=lambda msg: None) -> None:
+    cmd = [
+        'powershell',
+        '-ExecutionPolicy', 'Bypass',
+        '-File', ps_script,
+        settings_path,
+        '1'
+    ]
+    log_func('Running: ' + ' '.join(cmd))
+    subprocess.run(cmd, check=True)
+
+
+def kill_fusers() -> None:
+    if os.name == 'nt':
+        subprocess.run(['taskkill', '/IM', 'Fuser.exe', '/F'],
+                       stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+
 #==============================================================================
 # CONFIGURATION - APP ICON APPLICATION
 #==============================================================================
@@ -1695,6 +1766,7 @@ class VBS4Panel(tk.Frame):
         self.progress_job = None
         self.project_log_folder = None
         self.work_folder = None
+        self.last_build_dir = None
 
         tk.Button(
             self.log_frame, text="Clear Log",
@@ -1887,6 +1959,8 @@ class VBS4Panel(tk.Frame):
              "Launch PhotoMesh Wizard"),
             ("View Mesh", self.view_mesh,
              "Open TerraExplorer to view results"),
+            ("Post-Process Last Build", self.post_process_last_build,
+             "Run Reality Mesh processing on the last build"),
             ("One-Click Terrain Tutorial", self.show_terrain_tutorial,
              "Open help for the terrain tools")
         ]
@@ -2317,6 +2391,48 @@ class VBS4Panel(tk.Frame):
 
         self.log_message("One-Click Terrain Conversion completed.")
 
+    def post_process_last_build(self):
+        if not self.last_build_dir:
+            path = filedialog.askdirectory(title="Select Build_1/out Folder", parent=self)
+            if not path:
+                return
+            self.last_build_dir = path
+
+        def _run():
+            json_path = os.path.join(self.last_build_dir, 'Output-CenterPivotOrigin.json')
+            self.log_message(f"Waiting for {json_path}")
+            wait_for_file(json_path)
+            self.log_message("Output JSON detected")
+
+            with open(json_path, 'r', encoding='utf-8') as f:
+                data = json.load(f)
+            project_name = data.get('project_name', 'project')
+
+            proj_folder, data_folder = create_project_folder(self.last_build_dir, project_name)
+            self.log_message(f"Created project folder {proj_folder}")
+
+            copy_obj(self.last_build_dir, data_folder)
+            self.log_message("Copied OBJ files")
+
+            settings_path = os.path.join(proj_folder, f'{project_name}.txt')
+            write_project_settings(settings_path, data, data_folder)
+            self.log_message(f"Wrote settings {settings_path}")
+
+            ps_script = os.path.join(BASE_DIR, 'RealityMeshProcessor.ps1')
+            try:
+                run_processor(ps_script, settings_path, self.log_message)
+                self.log_message("Processing complete")
+            except Exception as e:
+                self.log_message(f"Processing failed: {e}")
+                messagebox.showerror("Error", str(e), parent=self)
+                return
+
+            kill_fusers()
+            self.log_message("PhotoMesh fusers closed")
+            messagebox.showinfo("Done", "Processing finished successfully", parent=self)
+
+        run_in_thread(_run)
+
     def show_terrain_tutorial(self):
         messagebox.showinfo("Terrain Tutorial", "One-Click Terrain Tutorial to be implemented.", parent=self)
 
@@ -2338,6 +2454,7 @@ class VBS4Panel(tk.Frame):
         """Begin monitoring PhotoMesh render logs under *project_path*."""
         self.project_log_folder = os.path.join(project_path, "Build_1", "out", "Log")
         self.work_folder = os.path.join(project_path, "Build_1", "out", "Work")
+        self.last_build_dir = os.path.join(project_path, "Build_1", "out")
         self.progress_var.set(0)
         self.progress_label.config(text="0%")
         if self.progress_job:

--- a/PythonPorjects/reality_mesh_gui.py
+++ b/PythonPorjects/reality_mesh_gui.py
@@ -1,0 +1,176 @@
+import tkinter as tk
+from tkinter import filedialog, messagebox, scrolledtext
+import threading
+import os
+import time
+import json
+import shutil
+import subprocess
+from datetime import datetime
+
+
+def load_system_settings(path: str) -> dict:
+    settings = {}
+    if os.path.isfile(path):
+        with open(path, 'r', encoding='utf-8') as f:
+            for line in f:
+                line = line.strip()
+                if not line or line.startswith('#') or '=' not in line:
+                    continue
+                key, value = line.split('=', 1)
+                settings[key.strip()] = value.strip()
+    return settings
+
+
+def wait_for_file(path: str, poll_interval: float = 5.0):
+    while not os.path.exists(path):
+        time.sleep(poll_interval)
+
+
+def create_project_folder(build_dir: str, project_name: str) -> str:
+    dt = datetime.now().strftime('%Y%m%d_%H%M%S')
+    project_folder = os.path.join(build_dir, f"{project_name}_{dt}")
+    os.makedirs(project_folder, exist_ok=True)
+    data_folder = os.path.join(project_folder, 'Data')
+    os.makedirs(data_folder, exist_ok=True)
+    return project_folder, data_folder
+
+
+def copy_obj(build_dir: str, data_folder: str):
+    src = os.path.join(build_dir, 'OBJ')
+    dst = os.path.join(data_folder, 'OBJ')
+    if os.path.isdir(src):
+        if os.path.exists(dst):
+            shutil.rmtree(dst)
+        shutil.copytree(src, dst)
+
+
+def write_project_settings(settings_path: str, data: dict, data_folder: str):
+    with open(settings_path, 'w', encoding='utf-8') as f:
+        project_name = data.get('project_name', 'project')
+        f.write(f"project_name={project_name}\n")
+        f.write(f"source_Directory={data_folder}\n")
+        for k, v in data.items():
+            if k == 'project_name':
+                continue
+            f.write(f"{k}={v}\n")
+
+
+def run_processor(ps_script: str, settings_path: str, log_fn):
+    cmd = [
+        'powershell',
+        '-ExecutionPolicy', 'Bypass',
+        '-File', ps_script,
+        settings_path,
+        '1'
+    ]
+    log_fn('Running: ' + ' '.join(cmd))
+    subprocess.run(cmd, check=True)
+
+
+def kill_fusers():
+    exe = 'Fuser.exe'
+    if os.name == 'nt':
+        subprocess.run(['taskkill', '/IM', exe, '/F'], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+
+
+class RealityMeshGUI(tk.Tk):
+    def __init__(self):
+        super().__init__()
+        self.title('Reality Mesh Post-Process')
+        self.geometry('600x400')
+
+        self.build_dir = tk.StringVar()
+        self.system_settings = tk.StringVar(value='RealityMeshSystemSettings.txt')
+        self.ps_script = tk.StringVar(value='RealityMeshProcessor.ps1')
+
+        self.create_widgets()
+
+    def create_widgets(self):
+        row = 0
+        tk.Label(self, text='Build_1/out Directory:').grid(row=row, column=0, sticky='w')
+        tk.Entry(self, textvariable=self.build_dir, width=50).grid(row=row, column=1, sticky='we')
+        tk.Button(self, text='Browse', command=self.browse_build).grid(row=row, column=2)
+        row += 1
+
+        tk.Label(self, text='System Settings File:').grid(row=row, column=0, sticky='w')
+        tk.Entry(self, textvariable=self.system_settings, width=50).grid(row=row, column=1, sticky='we')
+        tk.Button(self, text='Browse', command=self.browse_settings).grid(row=row, column=2)
+        row += 1
+
+        tk.Label(self, text='PowerShell Script:').grid(row=row, column=0, sticky='w')
+        tk.Entry(self, textvariable=self.ps_script, width=50).grid(row=row, column=1, sticky='we')
+        tk.Button(self, text='Browse', command=self.browse_ps).grid(row=row, column=2)
+        row += 1
+
+        tk.Button(self, text='Start', command=self.start_process).grid(row=row, column=0, pady=10)
+        tk.Button(self, text='Quit', command=self.destroy).grid(row=row, column=1)
+        row += 1
+
+        self.log = scrolledtext.ScrolledText(self, width=70, height=15)
+        self.log.grid(row=row, column=0, columnspan=3, pady=5)
+
+    def browse_build(self):
+        path = filedialog.askdirectory()
+        if path:
+            self.build_dir.set(path)
+
+    def browse_settings(self):
+        path = filedialog.askopenfilename(filetypes=[('Text Files','*.txt'), ('All Files','*.*')])
+        if path:
+            self.system_settings.set(path)
+
+    def browse_ps(self):
+        path = filedialog.askopenfilename(filetypes=[('PowerShell','*.ps1'), ('All Files','*.*')])
+        if path:
+            self.ps_script.set(path)
+
+    def log_msg(self, msg):
+        self.log.insert(tk.END, msg + '\n')
+        self.log.see(tk.END)
+
+    def start_process(self):
+        if not self.build_dir.get():
+            messagebox.showerror('Error', 'Please select a Build_1/out directory')
+            return
+        threading.Thread(target=self.run, daemon=True).start()
+
+    def run(self):
+        try:
+            build_dir = self.build_dir.get()
+            json_path = os.path.join(build_dir, 'Output-CenterPivotOrigin.json')
+            self.log_msg(f'Waiting for {json_path}')
+            wait_for_file(json_path)
+            self.log_msg('JSON found')
+
+            with open(json_path, 'r', encoding='utf-8') as f:
+                data = json.load(f)
+            project_name = data.get('project_name', 'project')
+            proj_folder, data_folder = create_project_folder(build_dir, project_name)
+            self.log_msg(f'Created project folder {proj_folder}')
+
+            copy_obj(build_dir, data_folder)
+            self.log_msg('Copied OBJ files')
+
+            settings_path = os.path.join(proj_folder, f'{project_name}.txt')
+            write_project_settings(settings_path, data, data_folder)
+            self.log_msg(f'Wrote settings {settings_path}')
+
+            run_processor(self.ps_script.get(), settings_path, self.log_msg)
+            self.log_msg('Processing complete')
+
+            kill_fusers()
+            self.log_msg('PhotoMesh fusers closed')
+            messagebox.showinfo('Done', 'Processing finished successfully')
+        except Exception as e:
+            messagebox.showerror('Error', str(e))
+            self.log_msg(f'Error: {e}')
+
+
+def main():
+    app = RealityMeshGUI()
+    app.mainloop()
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- integrate Reality Mesh post-processing helpers into `STE_Toolkit.py`
- remember last build folder and add **Post-Process Last Build** button
- run the processing pipeline from the toolkit when triggered

## Testing
- `python -m py_compile PythonPorjects/STE_Toolkit.py`
- `python -m py_compile PythonPorjects/reality_mesh_gui.py`
- `python -m py_compile PythonPorjects/reality_mesh_monitor.py`


------
https://chatgpt.com/codex/tasks/task_e_687fbbf04e74832292fed2ed35a1ced8

## Summary by Sourcery

Implement manual Reality Mesh post-processing workflow by integrating helper functions and UI command in the STE_Toolkit and adding a standalone Tkinter GUI app.

New Features:
- Add helper functions for loading settings, waiting for files, creating project folders, copying OBJ files, writing settings, running the PowerShell processor, and killing Fuser processes
- Add a “Post-Process Last Build” button in STE_Toolkit that remembers the last build directory and runs the processing pipeline in a background thread
- Persist the last build directory from the progress monitor to enable on-demand reprocessing
- Introduce reality_mesh_gui: a standalone Tkinter application for configuring and running the Reality Mesh post-processing pipeline