### PR TITLE
Add Reality Mesh standalone launcher

### DIFF
--- a/PythonPorjects/RealityMeshStandalone.py
+++ b/PythonPorjects/RealityMeshStandalone.py
@@ -1,0 +1,12 @@
+import os
+import sys
+
+# Ensure this script can locate the bundled GUI module regardless of where it's launched from
+BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+if BASE_DIR not in sys.path:
+    sys.path.insert(0, BASE_DIR)
+
+from reality_mesh_gui import main
+
+if __name__ == "__main__":
+    main()

--- a/PythonPorjects/STE_Toolkit.py
+++ b/PythonPorjects/STE_Toolkit.py
@@ -1961,6 +1961,8 @@ class VBS4Panel(tk.Frame):
              "Open TerraExplorer to view results"),
             ("Post-Process Last Build", self.post_process_last_build,
              "Run Reality Mesh processing on the last build"),
+            ("Open Standalone Post-Processor", self.open_reality_mesh_gui,
+             "Launch external GUI for Reality Mesh post-processing"),
             ("One-Click Terrain Tutorial", self.show_terrain_tutorial,
              "Open help for the terrain tools")
         ]
@@ -2435,6 +2437,9 @@ class VBS4Panel(tk.Frame):
 
     def show_terrain_tutorial(self):
         messagebox.showinfo("Terrain Tutorial", "One-Click Terrain Tutorial to be implemented.", parent=self)
+
+    def open_reality_mesh_gui(self):
+        subprocess.Popen(['python', 'RealityMeshStandalone.py'])
 
     def log_message(self, message):
          self.log_text.config(state="normal")


### PR DESCRIPTION
## Summary
- add `RealityMeshStandalone.py` utility for launching the reality mesh GUI
- expose a new button in `STE_Toolkit.py` that opens the standalone GUI

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687fc50157488322a22317e50c12a9d1