### PR TITLE
Fix running path for standalone GUI

### DIFF
--- a/PythonPorjects/STE_Toolkit.py
+++ b/PythonPorjects/STE_Toolkit.py
@@ -2484,7 +2484,9 @@ class VBS4Panel(tk.Frame):
         messagebox.showinfo("Terrain Tutorial", "One-Click Terrain Tutorial to be implemented.", parent=self)
 
     def open_reality_mesh_gui(self):
-        subprocess.Popen(['python', 'RealityMeshStandalone.py'])
+        script_dir = os.path.dirname(os.path.abspath(__file__))
+        script_path = os.path.join(script_dir, 'RealityMeshStandalone.py')
+        subprocess.Popen(['python', script_path])
 
     def log_message(self, message):
          self.log_text.config(state="normal")

--- a/README.md
+++ b/README.md
@@ -13,3 +13,14 @@ This repository contains automation scripts for processing PhotoMesh builds and 
 8. **Close PhotoMesh Fuser Processes** – All running `Fuser.exe` instances are terminated.
 
 The `distribution_paths.json` file lists remote VBS4 install paths. Update it with UNC paths to ensure terrain packages are synchronized across machines.
+
+## Running the Standalone Post‑Processor
+
+The GUI for post‑processing is located under `PythonPorjects/RealityMeshStandalone.py`.
+Launch it from the repository root with:
+
+```bash
+python PythonPorjects/RealityMeshStandalone.py
+```
+
+Avoid hard‑coded absolute paths so the tool can be executed from any checkout location.


### PR DESCRIPTION
## Summary
- allow `STE_Toolkit.py` to launch `RealityMeshStandalone.py` regardless of cwd
- document how to run the standalone post-processor

## Testing
- `python -m py_compile VBS4Project/PythonPorjects/STE_Toolkit.py`
- `python -m py_compile VBS4Project/PythonPorjects/RealityMeshStandalone.py`


------
https://chatgpt.com/codex/tasks/task_e_687fca1f26508322af86184b436bfcbd

## Summary by Sourcery

Fix the path resolution for launching the standalone post-processing GUI and document how to run it from any checkout location

Bug Fixes:
- Compute the absolute path to RealityMeshStandalone.py in STE_Toolkit before launching it

Documentation:
- Add a README section with instructions for running the standalone post-processor from the repository root