### PR TITLE
Add progress bar and VBS4 scrolling

### DIFF
--- a/PythonPorjects/STE_Toolkit.py
+++ b/PythonPorjects/STE_Toolkit.py
@@ -50,6 +50,24 @@ def run_in_thread(target, *args, **kwargs):
                              kwargs=kwargs, daemon=True)
     thread.start()
 
+
+class ScrollableFrame(tk.Frame):
+    """A vertically scrollable frame."""
+
+    def __init__(self, parent):
+        super().__init__(parent)
+        canvas = tk.Canvas(self, borderwidth=0, highlightthickness=0)
+        scrollbar = tk.Scrollbar(self, orient="vertical", command=canvas.yview)
+        self.inner = tk.Frame(canvas)
+        self.inner.bind(
+            "<Configure>",
+            lambda e: canvas.configure(scrollregion=canvas.bbox("all"))
+        )
+        canvas.create_window((0, 0), window=self.inner, anchor="nw")
+        canvas.configure(yscrollcommand=scrollbar.set)
+        canvas.pack(side="left", fill="both", expand=True)
+        scrollbar.pack(side="right", fill="y")
+
 # ---------------------------------------------------------------------------
 # PhotoMesh progress helpers
 # ---------------------------------------------------------------------------
@@ -1537,7 +1555,7 @@ class MainMenu(tk.Frame):
         controller.create_tutorial_button(self)   # <— keeps the “?” button
 
         tk.Label(
-            self,
+            self.content,
             text="STE Mission Planning Toolkit",
             font=("Helvetica", 36, "bold"),
             bg="black", fg="white", pady=20
@@ -1570,7 +1588,7 @@ class MainMenu(tk.Frame):
                     bg    = "#888888"
 
             button = tk.Button(
-                self,
+            self.content,
                 text=txt,
                 font=("Helvetica", 24),
                 bg=bg, fg="white",
@@ -1585,7 +1603,7 @@ class MainMenu(tk.Frame):
         state = "normal" if path and os.path.isfile(path) else "disabled"
         bg = "#444444" if state == "normal" else "#888888"
         tk.Button(
-            self,
+            self.content,
             text="Launch VBS4",
             font=("Helvetica", 24),
             bg=bg, fg="white",
@@ -1680,27 +1698,32 @@ class VBS4Panel(tk.Frame):
         super().__init__(parent)
         set_wallpaper(self)
         set_background(controller, self)
-        controller.create_tutorial_button(self)
-        self.create_battlespaces_button()
-        self.create_vbs4_folder_button()
         self.tooltip = Tooltip(self)
 
+        self.scroll_area = ScrollableFrame(self)
+        self.scroll_area.pack(fill="both", expand=True)
+        self.content = self.scroll_area.inner
+
+        controller.create_tutorial_button(self.content)
+        self.create_battlespaces_button()
+        self.create_vbs4_folder_button()
+
         tk.Label(
-            self,
+            self.content,
             text="VBS4 / BlueIG",
             font=("Helvetica", 36, "bold"),
             bg="black", fg="white", pady=20
         ).pack(fill="x")
 
          # VBS4 Launch frame
-        vbs4_frame = tk.Frame(self, bg="#333333")
+        vbs4_frame = tk.Frame(self.content, bg="#333333")
         vbs4_frame.pack(pady=8)
 
         vbs4_path = get_vbs4_install_path()
         logging.debug("VBS4 path for button creation: %s", vbs4_path)
 
         self.vbs4_button, self.vbs4_version_label = create_app_button(
-            self, "VBS4", get_vbs4_install_path, launch_vbs4,
+            self.content, "VBS4", get_vbs4_install_path, launch_vbs4,
             lambda: self.set_file_location("VBS4", "vbs4_path", self.vbs4_button)
         )
         self.update_vbs4_version()
@@ -1717,7 +1740,7 @@ class VBS4Panel(tk.Frame):
         self.update_vbs4_version()
 
         self.vbs4_launcher_button, _ = create_app_button(
-            self, "VBS4 Launcher", 
+            self.content, "VBS4 Launcher",
             lambda: config['General'].get('vbs4_setup_path', ''),
             launch_vbs4_setup,
             lambda: self.set_file_location("VBS4 Launcher", "vbs4_setup_path", self.vbs4_launcher_button)
@@ -1725,20 +1748,20 @@ class VBS4Panel(tk.Frame):
         self.update_vbs4_launcher_button_state()
 
         # BlueIG frame for dynamic buttons + version label handled below
-        self.blueig_frame = tk.Frame(self, bg="#333333")
+        self.blueig_frame = tk.Frame(self.content, bg="#333333")
         self.blueig_frame.pack(pady=8)
         self.create_blueig_button()
 
         # VBS License Manager button
         self.vbs_license_button, _ = create_app_button(
-            self, "VBS License Manager", 
+            self.content, "VBS License Manager",
             lambda: config['General'].get('vbs_license_manager_path', ''),
             self.launch_vbs_license_manager,
             lambda: self.set_file_location("VBS License Manager", "vbs_license_manager_path", self.vbs_license_button)
         )
 
         # Terrain Converter Section
-        self.terrain_frame = tk.Frame(self, bg="#333333")
+        self.terrain_frame = tk.Frame(self.content, bg="#333333")
         self.terrain_frame.pack(pady=8)
         self.terrain_button = tk.Button(
             self.terrain_frame,
@@ -1759,7 +1782,7 @@ class VBS4Panel(tk.Frame):
 
         # External Map button
         tk.Button(
-            self,
+            self.content,
             text="External Map",
             font=("Helvetica", 20),
             bg="#444", fg="white",
@@ -1768,7 +1791,7 @@ class VBS4Panel(tk.Frame):
 
         # Back to main menu
         tk.Button(
-            self,
+            self.content,
             text="Back",
             font=("Helvetica", 18),
             bg="red", fg="white",
@@ -1776,7 +1799,7 @@ class VBS4Panel(tk.Frame):
         ).pack(pady=20)
 
                # Log Window
-        self.log_frame = tk.Frame(self, bg="#222222")
+        self.log_frame = tk.Frame(self.content, bg="#222222")
         self.log_frame.pack(fill="x", padx=10, pady=(5, 10))
 
         tk.Label(
@@ -1828,7 +1851,7 @@ class VBS4Panel(tk.Frame):
 
         # Launch BlueIG button
         self.blueig_button, self.blueig_version_label = create_app_button(
-            self, "BlueIG", get_blueig_install_path, self.show_scenario_buttons,
+            self.content, "BlueIG", get_blueig_install_path, self.show_scenario_buttons,
             lambda: self.set_file_location("BlueIG", "blueig_path", self.blueig_button)
         )
         self.update_blueig_version()
@@ -1942,7 +1965,7 @@ class VBS4Panel(tk.Frame):
 
     def create_battlespaces_button(self):
         button = tk.Button(
-            self,
+            self.content,
             text="📁",
             font=("Helvetica", 16, "bold"),
             bg="orange", fg="black",
@@ -1957,7 +1980,7 @@ class VBS4Panel(tk.Frame):
 
     def create_vbs4_folder_button(self):
         button = tk.Button(
-            self,
+            self.content,
             text="📂",
             font=("Helvetica", 16, "bold"),
             bg="lightblue", fg="black",

--- a/PythonPorjects/reality_mesh_gui.py
+++ b/PythonPorjects/reality_mesh_gui.py
@@ -1,5 +1,5 @@
 import tkinter as tk
-from tkinter import filedialog, messagebox, scrolledtext
+from tkinter import filedialog, messagebox, scrolledtext, ttk
 from PIL import Image, ImageTk
 import threading
 import os
@@ -182,6 +182,9 @@ class RealityMeshGUI(tk.Tk):
 
         self.log = scrolledtext.ScrolledText(self, width=70, height=15)
         self.log.grid(row=row, column=0, columnspan=3, pady=5)
+        row += 1
+        self.status = ttk.Progressbar(self, mode='indeterminate')
+        self.status.grid(row=row, column=0, columnspan=3, sticky='we', padx=5)
 
     def browse_build(self):
         path = filedialog.askdirectory()
@@ -206,6 +209,7 @@ class RealityMeshGUI(tk.Tk):
         if not self.build_dir.get():
             messagebox.showerror('Error', 'Please select a Build_1/out directory')
             return
+        self.status.start(10)
         threading.Thread(target=self.run, daemon=True).start()
 
     def run(self):
@@ -238,6 +242,8 @@ class RealityMeshGUI(tk.Tk):
         except Exception as e:
             messagebox.showerror('Error', str(e))
             self.log_msg(f'Error: {e}')
+        finally:
+            self.status.stop()
 
 
 def main():


### PR DESCRIPTION
## Summary
- show a progress bar in Reality Mesh GUI while waiting
- create reusable `ScrollableFrame`
- make VBS4 panel scrollable so progress area stays visible

## Testing
- `python -m py_compile PythonPorjects/reality_mesh_gui.py PythonPorjects/STE_Toolkit.py`

------
https://chatgpt.com/codex/tasks/task_e_687fcf9c89048322a9206ad05d0a6dfb

## Summary by Sourcery

Add an indeterminate progress bar to the Reality Mesh GUI and introduce a reusable scrollable frame component to enable scrolling on the VBS4 panel.

New Features:
- Display an indeterminate progress bar in reality_mesh_gui during long-running operations
- Create a reusable ScrollableFrame class for vertical scrolling
- Wrap the VBS4 panel content in a ScrollableFrame to keep the progress area visible

Enhancements:
- Refactor VBS4 panel and related button containers to use ScrollableFrame.inner as the parent widget