### PR TITLE
Fix MainMenu content attribute

### DIFF
--- a/PythonPorjects/STE_Toolkit.py
+++ b/PythonPorjects/STE_Toolkit.py
@@ -1554,6 +1554,10 @@ class MainMenu(tk.Frame):
         set_background(controller, self)
         controller.create_tutorial_button(self)   # <— keeps the “?” button
 
+        # The main menu does not use a scrollable content frame like other
+        # panels, so simply use the frame itself as the content container.
+        self.content = self
+
         tk.Label(
             self.content,
             text="STE Mission Planning Toolkit",


### PR DESCRIPTION
## Summary
- fix `MainMenu` initialization by defining `self.content`

## Testing
- `python -m py_compile PythonPorjects/STE_Toolkit.py`

------
https://chatgpt.com/codex/tasks/task_e_687fd259a9a48322b1993ad865d8292a

## Summary by Sourcery

Bug Fixes:
- Initialize self.content in MainMenu to use the frame itself as the content container