### PR TITLE
Simplify Reality Mesh GUI defaults

### DIFF
--- a/PythonPorjects/reality_mesh_gui.py
+++ b/PythonPorjects/reality_mesh_gui.py
@@ -138,8 +138,15 @@ class RealityMeshGUI(tk.Tk):
         self.logo_photo = None
 
         self.build_dir = tk.StringVar()
-        self.system_settings = tk.StringVar(value='RealityMeshSystemSettings.txt')
-        self.ps_script = tk.StringVar(value='RealityMeshProcessor.ps1')
+        base_dir = os.path.dirname(os.path.abspath(__file__))
+        photomesh_dir = os.path.join(base_dir, 'photomesh')
+
+        self.system_settings = tk.StringVar(
+            value=os.path.join(photomesh_dir, 'RealityMeshSystemSettings.txt')
+        )
+        self.ps_script = tk.StringVar(
+            value=os.path.join(photomesh_dir, 'RealityMeshProcess.ps1')
+        )
 
         self.create_widgets()
 
@@ -147,8 +154,7 @@ class RealityMeshGUI(tk.Tk):
         row = 0
         instructions = (
             "1. Select the Build_1/out folder from PhotoMesh.\n"
-            "2. Confirm the settings and script paths.\n"
-            "3. Click Start to generate the terrain package."
+            "2. Click Start to generate the terrain package."
         )
         tk.Label(self, text=instructions, justify='left').grid(row=row, column=0, columnspan=3, sticky='w', padx=5)
         row += 1
@@ -166,24 +172,18 @@ class RealityMeshGUI(tk.Tk):
 
         lbl_settings = tk.Label(self, text='System Settings File:')
         lbl_settings.grid(row=row, column=0, sticky='w')
-        ent_settings = tk.Entry(self, textvariable=self.system_settings, width=50)
+        ent_settings = tk.Entry(self, textvariable=self.system_settings, width=50, state='readonly')
         ent_settings.grid(row=row, column=1, sticky='we')
-        btn_settings = tk.Button(self, text='Browse', command=self.browse_settings)
-        btn_settings.grid(row=row, column=2)
         ToolTip(lbl_settings, 'Text file containing system configuration values.')
         ToolTip(ent_settings, 'Path to RealityMeshSystemSettings.txt.')
-        ToolTip(btn_settings, 'Choose the settings file.')
         row += 1
 
         lbl_ps = tk.Label(self, text='PowerShell Script:')
         lbl_ps.grid(row=row, column=0, sticky='w')
-        ent_ps = tk.Entry(self, textvariable=self.ps_script, width=50)
+        ent_ps = tk.Entry(self, textvariable=self.ps_script, width=50, state='readonly')
         ent_ps.grid(row=row, column=1, sticky='we')
-        btn_ps = tk.Button(self, text='Browse', command=self.browse_ps)
-        btn_ps.grid(row=row, column=2)
-        ToolTip(lbl_ps, 'RealityMeshProcessor.ps1 script used for processing.')
+        ToolTip(lbl_ps, 'RealityMeshProcess.ps1 script used for processing.')
         ToolTip(ent_ps, 'Path to the processing PowerShell script.')
-        ToolTip(btn_ps, 'Select the PowerShell script.')
         row += 1
 
         btn_start = tk.Button(self, text='Start', command=self.start_process)

--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@ This repository contains automation scripts for processing PhotoMesh builds and 
 ## Post-Project Wizard Steps
 1. **Generate Project Structure** – After PhotoMesh finishes generating OBJ files in `Build_1/out`, the toolkit creates an output folder for the project.
 2. **Create `/Data` Folder and Copy OBJs** – The entire OBJ directory is copied into `Data/OBJ` inside the new project folder.
-3. **Create Project Settings File** – A text file next to `Data` stores project metadata and configuration for the `RealityMeshProcessor.ps1` script.
+3. **Create Project Settings File** – A text file next to `Data` stores project metadata and configuration for the `RealityMeshProcess.ps1` script.
 4. **(Optional) Split Mesh into 4 Sub‑Projects** – If implemented, the mesh can be divided into four regions for parallel processing.
-5. **Trigger Reality Mesh PowerShell Script** – `RealityMeshProcessor.ps1` is executed with the settings file to build the VBS4 terrain package.
+5. **Trigger Reality Mesh PowerShell Script** – `RealityMeshProcess.ps1` is executed with the settings file to build the VBS4 terrain package.
 6. **Done Message and Log File** – Processing progress is logged and a completion message is displayed.
 7. **Progress Bar** – The GUI now shows a status bar indicating processing percentage while the Reality Mesh script runs.
 8. **Copy Output to All VBS4 Install Locations** – Generated terrain is replicated to all configured VBS4 installations as defined in `distribution_paths.json`.
@@ -25,3 +25,6 @@ python PythonPorjects/RealityMeshStandalone.py
 ```
 
 Avoid hard‑coded absolute paths so the tool can be executed from any checkout location.
+The required `RealityMeshProcess.ps1` script and `RealityMeshSystemSettings.txt` file
+are bundled under `PythonPorjects/photomesh`. The GUI automatically points to these
+files so the user only needs to browse to the `Build_1/out` folder.


### PR DESCRIPTION
## Summary
- set RealityMesh GUI to automatically use bundled photomesh scripts
- display system settings and PS script as read‑only
- update workflow docs for `RealityMeshProcess.ps1`

## Testing
- `python -m py_compile PythonPorjects/reality_mesh_gui.py`

------
https://chatgpt.com/codex/tasks/task_e_687fe767e17c83228a45bc341c8e4ecf