### PR TITLE
Remove hard-coded Reality Mesh paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -158,3 +158,7 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+# Local Reality Mesh settings files
+RealityMeshSystemSettings.txt
+PythonPorjects/photomesh/RealityMeshSystemSettings.txt

--- a/PythonPorjects/photomesh/RealityMeshProcess.ps1
+++ b/PythonPorjects/photomesh/RealityMeshProcess.ps1
@@ -160,14 +160,15 @@ if ($AREYOUSURE -eq 'y') {
 		$override_Installation_VBS4_bool = "true"
 	}
 
-	$out_in_name = "$project_name"
-	$out_in_name_with_drive = ""
-	if ($override_Installation_DevSuite -eq 1) {
-		$out_in_name_with_drive = "${override_Path_DevSuite}:\temp\RealityMesh\$project_name"
-	}
-	else {
-		$out_in_name_with_drive = "P:\temp\RealityMesh\$project_name"
-	}
+        $out_in_name = "$project_name"
+        $out_in_name_with_drive = ""
+        if ($override_Installation_DevSuite -eq 1) {
+                $out_in_name_with_drive = "${override_Path_DevSuite}:\temp\RealityMesh\$project_name"
+        }
+        else {
+                $tempDir = Join-Path $env:TEMP 'RealityMesh'
+                $out_in_name_with_drive = Join-Path $tempDir $project_name
+        }
 	
 	New-Item -Path $generated_settings_file -ItemType File
 	Add-Content -Path $generated_settings_file -Value "set name {$project_name}"

--- a/PythonPorjects/photomesh/RealityMeshSystemSettings.example.txt
+++ b/PythonPorjects/photomesh/RealityMeshSystemSettings.example.txt
@@ -1,0 +1,8 @@
+blender_path=<path to blender>
+blender_threads=6
+override_Installation_VBS4=1
+override_Path_VBS4=<path to VBS4>
+vbs4_version=<version>
+override_Installation_DevSuite=0
+override_Path_DevSuite=<dev suite path or drive>
+terratools_ssh_path=<path to terratoolssh.exe>

--- a/PythonPorjects/photomesh/RealityMeshSystemSettings.txt
+++ b/PythonPorjects/photomesh/RealityMeshSystemSettings.txt
@@ -1,8 +1,0 @@
-blender_path=C:\Program Files\Blender\blender-4.3.0-windows-x64\blender.exe
-blender_threads=6
-override_Installation_VBS4=1
-override_Path_VBS4=C:\Bohemia Interactive Simulations\VBS4 24.2 YYMEA_General
-vbs4_version=VBS4_24_2
-override_Installation_DevSuite=0
-override_Path_DevSuite=P
-terratools_ssh_path=C:\Program Files\Bohemia Interactive Simulations\TerraTools\bin\terratoolssh.exe

--- a/PythonPorjects/photomesh/SetupSystemSettingsREADME.txt
+++ b/PythonPorjects/photomesh/SetupSystemSettingsREADME.txt
@@ -1,15 +1,14 @@
-You will need to create a text file in this folder named RealityMeshSystemSettings.txt.  In it you will include the contents below, adjusted after the = signs to point to the appropriate values on your machine.
-These are just example values, you will want to configure everything to your specific machine.  This only needs created once.  The items below should be all that is in the file.  To note, 1 = true, 0 = false
+Copy `RealityMeshSystemSettings.example.txt` to `RealityMeshSystemSettings.txt` in this folder and update the values to match your system. The items below are sample values; adjust them after the `=` signs. To note, 1 = true and 0 = false.
 
-blender_path=C:\Program Files\Blender Foundation\Blender 4.2\blender.exe
+blender_path=<path to blender>
 blender_threads=6
 override_Installation_VBS4=1
-override_Path_VBS4=F:\VBS4_24_2
-vbs4_version=VBS4_24_2
+override_Path_VBS4=<path to VBS4>
+vbs4_version=<version>
 override_Installation_DevSuite=0
-override_Path_DevSuite=P
-terratools_ssh_path=E:\Perforce\depot\main\terrasim\bin\terratoolssh.exe
+override_Path_DevSuite=<dev suite path or drive>
+terratools_ssh_path=<path to terratoolssh.exe>
 
 ###This line can be used to configure a loose files/dev build of terratools to work with the script // dont include lines with ### in the final settings file
-terratools_home_path=E:\Perforce\depot\main\terrasim  
+terratools_home_path=<path to terratools home>
 ###

--- a/PythonPorjects/reality_mesh_gui.py
+++ b/PythonPorjects/reality_mesh_gui.py
@@ -141,9 +141,11 @@ class RealityMeshGUI(tk.Tk):
         base_dir = os.path.dirname(os.path.abspath(__file__))
         photomesh_dir = os.path.join(base_dir, 'photomesh')
 
-        self.system_settings = tk.StringVar(
-            value=os.path.join(photomesh_dir, 'RealityMeshSystemSettings.txt')
-        )
+        default_settings = os.path.join(photomesh_dir, 'RealityMeshSystemSettings.txt')
+        if not os.path.isfile(default_settings):
+            default_settings = os.path.join(photomesh_dir, 'RealityMeshSystemSettings.example.txt')
+
+        self.system_settings = tk.StringVar(value=default_settings)
         self.ps_script = tk.StringVar(
             value=os.path.join(photomesh_dir, 'RealityMeshProcess.ps1')
         )

--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@ python PythonPorjects/RealityMeshStandalone.py
 ```
 
 Avoid hard‑coded absolute paths so the tool can be executed from any checkout location.
-The required `RealityMeshProcess.ps1` script and `RealityMeshSystemSettings.txt` file
-are bundled under `PythonPorjects/photomesh`. The GUI automatically points to these
-files so the user only needs to browse to the `Build_1/out` folder.
+The required `RealityMeshProcess.ps1` script and an example settings file
+`RealityMeshSystemSettings.example.txt` are bundled under
+`PythonPorjects/photomesh`. Copy the example file to
+`RealityMeshSystemSettings.txt` and edit the paths for your system. The GUI
+automatically points to these files so the user only needs to browse to the
+`Build_1/out` folder.

--- a/RealityMeshSystemSettings.example.txt
+++ b/RealityMeshSystemSettings.example.txt
@@ -1,0 +1,9 @@
+blender_path=<path to blender>
+blender_threads=6
+override_Installation_VBS4=1
+override_Path_VBS4=<path to VBS4>
+vbs4_version=<version>
+override_Installation_DevSuite=0
+override_Path_DevSuite=<dev suite path or drive>
+terratools_ssh_path=<path to terratoolssh.exe>
+terratools_home_path=<path to terratools home>

--- a/RealityMeshSystemSettings.txt
+++ b/RealityMeshSystemSettings.txt
@@ -1,9 +1,0 @@
-blender_path=C:\Program Files\Blender Foundation\Blender 4.2\blender.exe
-blender_threads=6
-override_Installation_VBS4=1
-override_Path_VBS4=F:\VBS4_24_2
-vbs4_version=VBS4_24_2
-override_Installation_DevSuite=0
-override_Path_DevSuite=P
-terratools_ssh_path=E:\Perforce\depot\main\terrasim\bin\terratoolssh.exe
-terratools_home_path=E:\Perforce\depot\main\terrasim


### PR DESCRIPTION
## Summary
- avoid user-specific paths in RealityMesh system settings
- look for a real settings file and fall back to example settings
- remove fixed `P:` drive usage in the PowerShell script
- note example settings in README and setup instructions
- ignore user-created settings files in `.gitignore`

## Testing
- `python -m py_compile PythonPorjects/reality_mesh_gui.py`
- `python -m py_compile PythonPorjects/reality_mesh_monitor.py`

------
https://chatgpt.com/codex/tasks/task_e_687fed4652088322bf370c96e7650eb2