### PR TITLE
Update Blender defaults and detection

### DIFF
--- a/PythonPorjects/STE_Toolkit.py
+++ b/PythonPorjects/STE_Toolkit.py
@@ -321,15 +321,16 @@ def write_project_settings(settings_path: str, data: dict, data_folder: str) -> 
 
 
 def run_processor(ps_script: str, settings_path: str, log_func=lambda msg: None) -> None:
-    cmd = [
-        'powershell',
-        '-ExecutionPolicy', 'Bypass',
-        '-File', ps_script,
-        settings_path,
-        '1'
-    ]
-    log_func('Running: ' + ' '.join(cmd))
-    subprocess.run(cmd, check=True)
+    """Run the Reality Mesh PowerShell script via a project-specific batch file."""
+    batch_path = os.path.join(os.path.dirname(settings_path), 'RealityMeshProcess.bat')
+
+    with open(batch_path, 'w', encoding='utf-8') as f:
+        f.write(
+            f'start "" powershell -executionpolicy bypass "{ps_script}" "{settings_path}" 1\n'
+        )
+
+    log_func(f'Created batch file {batch_path}')
+    subprocess.run(batch_path, check=True)
 
 
 def get_distribution_paths() -> list[str]:

--- a/PythonPorjects/photomesh/RealityMeshProcess.ps1
+++ b/PythonPorjects/photomesh/RealityMeshProcess.ps1
@@ -59,10 +59,27 @@ $srfResolution = (Get-Content "$project_settings_File" | Where-Object { $_ -matc
 
 #System settings
 $blender_path = (Get-Content "$system_settings" | Where-Object { $_ -match "^blender_path=" }) -replace "blender_path=", ""
-if (!(Test-Path $blender_path)) {	
-	Write-Output "Blender Path invalid"
-	Read-Host -Prompt "Press Enter to exit"
-	Return
+$default_blender = "C:\\Program Files\\Blender Foundation\\Blender 4.5\\blender.exe"
+if (!(Test-Path $blender_path)) {
+        if (Test-Path $default_blender) {
+                $blender_path = $default_blender
+                Write-Output "Using Blender found at $blender_path"
+        } else {
+                $search = Get-ChildItem "C:\\Program Files\\Blender Foundation" -Directory -ErrorAction SilentlyContinue |
+                    Sort-Object Name -Descending |
+                    ForEach-Object { Join-Path $_.FullName 'blender.exe' } |
+                    Where-Object { Test-Path $_ } |
+                    Select-Object -First 1
+
+                if ($search) {
+                        $blender_path = $search
+                        Write-Output "Using Blender found at $blender_path"
+                } else {
+                        Write-Output "Blender Path invalid"
+                        Read-Host -Prompt "Press Enter to exit"
+                        Return
+                }
+        }
 }
 $blender_threads = (Get-Content "$system_settings" | Where-Object { $_ -match "^blender_threads=" }) -replace "blender_threads=", ""
 $override_Installation_VBS4 = (Get-Content "$system_settings" | Where-Object { $_ -match "^override_Installation_VBS4=" }) -replace "override_Installation_VBS4=", ""

--- a/PythonPorjects/photomesh/RealityMeshSystemSettings.txt
+++ b/PythonPorjects/photomesh/RealityMeshSystemSettings.txt
@@ -1,4 +1,4 @@
-blender_path=C:\Program Files\Blender\blender-4.3.0-windows-x64\blender.exe
+blender_path=C:\Program Files\Blender Foundation\Blender 4.5\blender.exe
 blender_threads=6
 override_Installation_VBS4=1
 override_Path_VBS4=C:\Bohemia Interactive Simulations\VBS4 24.2 YYMEA_General
@@ -6,3 +6,4 @@ vbs4_version=VBS4_24_2
 override_Installation_DevSuite=0
 override_Path_DevSuite=P
 terratools_ssh_path=C:\Program Files\Bohemia Interactive Simulations\TerraTools\bin\terratoolssh.exe
+terratools_home_path=C:\Program Files\Bohemia Interactive Simulations\TerraTools

--- a/PythonPorjects/photomesh/SetupSystemSettingsREADME.txt
+++ b/PythonPorjects/photomesh/SetupSystemSettingsREADME.txt
@@ -1,15 +1,16 @@
 You will need to create a text file in this folder named RealityMeshSystemSettings.txt.  In it you will include the contents below, adjusted after the = signs to point to the appropriate values on your machine.
 These are just example values, you will want to configure everything to your specific machine.  This only needs created once.  The items below should be all that is in the file.  To note, 1 = true, 0 = false
 
-blender_path=C:\Program Files\Blender Foundation\Blender 4.2\blender.exe
+blender_path=C:\Program Files\Blender Foundation\Blender 4.5\blender.exe
 blender_threads=6
 override_Installation_VBS4=1
 override_Path_VBS4=F:\VBS4_24_2
 vbs4_version=VBS4_24_2
 override_Installation_DevSuite=0
 override_Path_DevSuite=P
-terratools_ssh_path=E:\Perforce\depot\main\terrasim\bin\terratoolssh.exe
+terratools_ssh_path=C:\Program Files\Bohemia Interactive Simulations\TerraTools\bin\terratoolssh.exe
 
 ###This line can be used to configure a loose files/dev build of terratools to work with the script // dont include lines with ### in the final settings file
-terratools_home_path=E:\Perforce\depot\main\terrasim  
-###
+terratools_home_path=C:\Program Files\Bohemia Interactive Simulations\TerraTools
+
+# Optional: set paths to other tools such as ModelExchanger if required.

--- a/PythonPorjects/reality_mesh_monitor.py
+++ b/PythonPorjects/reality_mesh_monitor.py
@@ -60,16 +60,16 @@ def write_project_settings(settings_path: str, data: dict, data_folder: str) -> 
 
 
 def run_processor(ps_script: str, settings_path: str) -> None:
-    """Run the RealityMeshProcessor PowerShell script."""
-    cmd = [
-        'powershell',
-        '-ExecutionPolicy', 'Bypass',
-        '-File', ps_script,
-        settings_path,
-        '1'
-    ]
-    print('Running:', ' '.join(cmd))
-    subprocess.run(cmd, check=True)
+    """Run the Reality Mesh PowerShell script via a project-specific batch file."""
+    batch_path = os.path.join(os.path.dirname(settings_path), 'RealityMeshProcess.bat')
+
+    with open(batch_path, 'w', encoding='utf-8') as f:
+        f.write(
+            f'start "" powershell -executionpolicy bypass "{ps_script}" "{settings_path}" 1\n'
+        )
+
+    print(f'Created batch file {batch_path}')
+    subprocess.run(batch_path, check=True)
 
 
 def main() -> None:

--- a/README.md
+++ b/README.md
@@ -28,3 +28,18 @@ Avoid hard‑coded absolute paths so the tool can be executed from any checkout 
 The required `RealityMeshProcess.ps1` script and `RealityMeshSystemSettings.txt` file
 are bundled under `PythonPorjects/photomesh`. The GUI automatically points to these
 files so the user only needs to browse to the `Build_1/out` folder.
+
+### Configuring Tool Paths
+
+Edit `PythonPorjects/photomesh/RealityMeshSystemSettings.txt` to point to your
+local installations of Blender and TerraTools. For Bisim standard installs you
+can use:
+
+```
+blender_path=C:\Program Files\Blender Foundation\Blender 4.5\blender.exe
+terratools_ssh_path=C:\Program Files\Bohemia Interactive Simulations\TerraTools\bin\terratoolssh.exe
+terratools_home_path=C:\Program Files\Bohemia Interactive Simulations\TerraTools
+```
+
+Adjust these paths if your installers reside elsewhere or you need to reference
+additional tools like ModelExchanger.

--- a/RealityMeshSystemSettings.txt
+++ b/RealityMeshSystemSettings.txt
@@ -1,9 +1,9 @@
-blender_path=C:\Program Files\Blender Foundation\Blender 4.2\blender.exe
+blender_path=C:\Program Files\Blender Foundation\Blender 4.5\blender.exe
 blender_threads=6
 override_Installation_VBS4=1
 override_Path_VBS4=F:\VBS4_24_2
 vbs4_version=VBS4_24_2
 override_Installation_DevSuite=0
 override_Path_DevSuite=P
-terratools_ssh_path=E:\Perforce\depot\main\terrasim\bin\terratoolssh.exe
-terratools_home_path=E:\Perforce\depot\main\terrasim
+terratools_ssh_path=C:\Program Files\Bohemia Interactive Simulations\TerraTools\bin\terratoolssh.exe
+terratools_home_path=C:\Program Files\Bohemia Interactive Simulations\TerraTools


### PR DESCRIPTION
## Summary
- default Blender path and docs use Blender 4.5
- RealityMeshProcess.ps1 checks a 4.5 install before scanning Program Files

## Testing
- `git ls-files '*.py' | while read file; do python -m py_compile "$file"; done`

------
https://chatgpt.com/codex/tasks/task_e_6881021229cc8322a49e1784f849b0c6

## Summary by Sourcery

Improve Blender path handling by defaulting to Blender 4.5 or auto-discovering installations, switch Python processors to use generated batch files for invoking PowerShell, and update documentation with configuration guidance.

Enhancements:
- Add fallback logic in RealityMeshProcess.ps1 to use Blender 4.5 or auto-detect the latest installed version when the configured path is invalid
- Modify run_processor in reality_mesh_monitor.py and STE_Toolkit.py to create and execute a project-specific batch file for invoking the PowerShell script

Documentation:
- Add "Configuring Tool Paths" section to README with default paths for Blender 4.5 and TerraTools