### PR TITLE
Add dataset root setting for project creation

### DIFF
--- a/PythonPorjects/STE_Toolkit.py
+++ b/PythonPorjects/STE_Toolkit.py
@@ -291,9 +291,21 @@ def wait_for_file(path: str, poll_interval: float = 5.0) -> None:
         time.sleep(poll_interval)
 
 
-def create_project_folder(build_dir: str, project_name: str) -> tuple[str, str]:
-    dt = datetime.now().strftime('%Y%m%d_%H%M%S')
-    proj_folder = os.path.join(build_dir, f"{project_name}_{dt}")
+def create_project_folder(build_dir: str, project_name: str, dataset_root: str | None = None) -> tuple[str, str]:
+    """Create the project directory structure used by Reality Mesh.
+
+    When *dataset_root* is supplied the folder is created there using just
+    the project name.  Otherwise it is created under *build_dir* and
+    includes a timestamp suffix as before.
+    """
+
+    if dataset_root:
+        os.makedirs(dataset_root, exist_ok=True)
+        proj_folder = os.path.join(dataset_root, project_name)
+    else:
+        dt = datetime.now().strftime('%Y%m%d_%H%M%S')
+        proj_folder = os.path.join(build_dir, f"{project_name}_{dt}")
+
     os.makedirs(proj_folder, exist_ok=True)
     data_folder = os.path.join(proj_folder, 'Data')
     os.makedirs(data_folder, exist_ok=True)
@@ -2455,7 +2467,9 @@ class VBS4Panel(tk.Frame):
                 data = json.load(f)
             project_name = data.get('project_name', 'project')
 
-            proj_folder, data_folder = create_project_folder(self.last_build_dir, project_name)
+            settings = load_system_settings(os.path.join(BASE_DIR, 'photomesh', 'RealityMeshSystemSettings.txt'))
+            dataset_root = settings.get('dataset_root')
+            proj_folder, data_folder = create_project_folder(self.last_build_dir, project_name, dataset_root)
             self.log_message(f"Created project folder {proj_folder}")
 
             copy_obj(self.last_build_dir, data_folder)

--- a/PythonPorjects/photomesh/RealityMeshSystemSettings.txt
+++ b/PythonPorjects/photomesh/RealityMeshSystemSettings.txt
@@ -7,3 +7,4 @@ override_Installation_DevSuite=0
 override_Path_DevSuite=P
 terratools_ssh_path=C:\Program Files\Bohemia Interactive Simulations\TerraTools\bin\terratoolssh.exe
 terratools_home_path=C:\Program Files\Bohemia Interactive Simulations\TerraTools
+dataset_root=C:\BiSim OneClick\Datasets

--- a/PythonPorjects/photomesh/SetupSystemSettingsREADME.txt
+++ b/PythonPorjects/photomesh/SetupSystemSettingsREADME.txt
@@ -14,3 +14,4 @@ terratools_ssh_path=C:\Program Files\Bohemia Interactive Simulations\TerraTools\
 terratools_home_path=C:\Program Files\Bohemia Interactive Simulations\TerraTools
 
 # Optional: set paths to other tools such as ModelExchanger if required.
+dataset_root=C:\BiSim OneClick\Datasets  # where project folders will be stored

--- a/PythonPorjects/reality_mesh_gui.py
+++ b/PythonPorjects/reality_mesh_gui.py
@@ -29,9 +29,22 @@ def wait_for_file(path: str, poll_interval: float = 5.0):
         time.sleep(poll_interval)
 
 
-def create_project_folder(build_dir: str, project_name: str) -> str:
-    dt = datetime.now().strftime('%Y%m%d_%H%M%S')
-    project_folder = os.path.join(build_dir, f"{project_name}_{dt}")
+def create_project_folder(build_dir: str, project_name: str, dataset_root: str | None = None) -> str:
+    """Create the project directory structure.
+
+    If *dataset_root* is provided, the project is created under that
+    directory using just the project name (no timestamp).  Otherwise the
+    folder is created inside *build_dir* with a timestamp suffix as
+    before.
+    """
+
+    if dataset_root:
+        os.makedirs(dataset_root, exist_ok=True)
+        project_folder = os.path.join(dataset_root, project_name)
+    else:
+        dt = datetime.now().strftime('%Y%m%d_%H%M%S')
+        project_folder = os.path.join(build_dir, f"{project_name}_{dt}")
+
     os.makedirs(project_folder, exist_ok=True)
     data_folder = os.path.join(project_folder, 'Data')
     os.makedirs(data_folder, exist_ok=True)
@@ -247,7 +260,10 @@ class RealityMeshGUI(tk.Tk):
             with open(json_path, 'r', encoding='utf-8') as f:
                 data = json.load(f)
             project_name = data.get('project_name', 'project')
-            proj_folder, data_folder = create_project_folder(build_dir, project_name)
+
+            settings = load_system_settings(self.system_settings.get())
+            dataset_root = settings.get('dataset_root')
+            proj_folder, data_folder = create_project_folder(build_dir, project_name, dataset_root)
             self.log_msg(f'Created project folder {proj_folder}')
 
             copy_obj(build_dir, data_folder)

--- a/README.md
+++ b/README.md
@@ -39,7 +39,11 @@ can use:
 blender_path=C:\Program Files\Blender Foundation\Blender 4.5\blender.exe
 terratools_ssh_path=C:\Program Files\Bohemia Interactive Simulations\TerraTools\bin\terratoolssh.exe
 terratools_home_path=C:\Program Files\Bohemia Interactive Simulations\TerraTools
+dataset_root=C:\BiSim OneClick\Datasets
 ```
+
+`dataset_root` specifies where new project folders are created before
+running the Reality Mesh process.
 
 Adjust these paths if your installers reside elsewhere or you need to reference
 additional tools like ModelExchanger.


### PR DESCRIPTION
## Summary
- add `dataset_root` path to system settings template
- use `dataset_root` when creating project folders in the GUI and STE Toolkit
- update setup instructions and README with new setting

## Testing
- `python -m py_compile PythonPorjects/reality_mesh_gui.py PythonPorjects/STE_Toolkit.py`

------
https://chatgpt.com/codex/tasks/task_e_68812214ff288322a2762b29cc87c0d4

## Summary by Sourcery

Introduce a new dataset_root setting to control where project folders are created and apply it in both the GUI and STE Toolkit workflows.

New Features:
- Add dataset_root path to the system settings template

Enhancements:
- Extend create_project_folder to accept a dataset_root and use it to place projects in a central directory when provided
- Load and apply the dataset_root setting when creating projects in the Reality Mesh GUI and STE Toolkit

Documentation:
- Update README and setup instructions to document the new dataset_root setting