### PR TITLE
Add BiSim path section to settings

### DIFF
--- a/PythonPorjects/post_process_utils.py
+++ b/PythonPorjects/post_process_utils.py
@@ -1,0 +1,112 @@
+import os
+import shutil
+import subprocess
+import json
+from datetime import datetime
+
+
+BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+
+
+def create_project_structure(project_name: str, base_folder: str) -> tuple[str, str]:
+    """Create a timestamped project directory under *base_folder*.
+
+    Returns the project folder path and its data subfolder. If the project
+    folder already exists, it is reused.
+    """
+    ts = datetime.now().strftime('%Y%m%d_%H%M%S')
+    project_folder = os.path.join(base_folder, f"{project_name}_{ts}")
+    data_folder = os.path.join(project_folder, 'data')
+    os.makedirs(data_folder, exist_ok=True)
+    return project_folder, data_folder
+
+
+def copy_obj_folder(src_obj: str, data_folder: str) -> str:
+    """Copy *src_obj* directory into *data_folder* as 'OBJ'."""
+    dest = os.path.join(data_folder, 'OBJ')
+    if os.path.exists(dest):
+        shutil.rmtree(dest)
+    shutil.copytree(src_obj, dest)
+    return dest
+
+
+def parse_centerpivot_json(json_path: str, project_name: str) -> dict:
+    """Parse Output-CenterPivotOrigin.json and return offset info."""
+    with open(json_path, 'r', encoding='utf-8') as f:
+        data = json.load(f)
+
+    origin = data.get('Origin', [0, 0, 0])
+    wkt = data.get('WKT') or data.get('UTM', '')
+    return {
+        'project_name': project_name,
+        'offset_x': origin[0],
+        'offset_y': origin[1],
+        'offset_z': origin[2],
+        'offset_coordsys': wkt,
+    }
+
+
+def create_settings_file(info: dict, project_folder: str) -> str:
+    """Write the Reality Mesh settings file using *info*.
+
+    A matching folder is created under ``C:\BiSim OneClick\Datasets`` and used
+    for both the ``source_Directory`` value and a ``[BiSimOneClickPath]``
+    section.
+    """
+    settings_path = os.path.join(project_folder, f"{info['project_name']}.txt")
+    dataset_root = os.path.join('C:\\BiSim OneClick\\Datasets', info['project_name'])
+    dataset_data = os.path.join(dataset_root, 'data')
+    os.makedirs(dataset_data, exist_ok=True)
+
+    lines = [
+        f"project_name={info['project_name']}",
+        f"source_Directory={dataset_data}",
+        f"offset_coordsys={info.get('offset_coordsys', '')}",
+        "offset_hdatum=WGS84",
+        "offset_vdatum=WGS84_ellipsoid",
+        f"offset_x={info['offset_x']}",
+        f"offset_y={info['offset_y']}",
+        f"offset_z={info['offset_z']}",
+        "orthocam_Resolution=0.05",
+        "orthocam_Render_Lowest=1",
+        "",
+        "[BiSimOneClickPath]",
+        f"path={dataset_data}",
+    ]
+
+    with open(settings_path, 'w', encoding='utf-8') as f:
+        for line in lines:
+            f.write(line + '\n')
+    return settings_path
+
+
+def run_powershell(ps_script: str, settings_file: str) -> None:
+    cmd = [
+        'powershell',
+        '-ExecutionPolicy', 'Bypass',
+        '-File', ps_script,
+        settings_file,
+        '1',
+    ]
+    print('Running:', ' '.join(cmd))
+    subprocess.run(cmd, check=True)
+    subprocess.run(['taskkill', '/IM', 'Fuser.exe', '/F'])
+
+
+def distribute_to_installs(result_folder: str) -> None:
+    """Copy *result_folder* to VBS4 installs listed in distribution_paths.json."""
+    dist_file = os.path.join(BASE_DIR, 'distribution_paths.json')
+    if not os.path.isfile(dist_file):
+        return
+    with open(dist_file, 'r', encoding='utf-8') as f:
+        paths = json.load(f).get('paths', [])
+
+    for path in paths:
+        dest = os.path.join(path, os.path.basename(result_folder))
+        try:
+            if os.path.exists(dest):
+                shutil.rmtree(dest)
+            shutil.copytree(result_folder, dest)
+            print('Copied result to', dest)
+        except Exception as e:
+            print('Failed to copy to', dest, ':', e)

--- a/PythonPorjects/reality_mesh_monitor.py
+++ b/PythonPorjects/reality_mesh_monitor.py
@@ -60,6 +60,12 @@ def _parse_offset_coordsys(wkt: str) -> str:
 
 
 def write_project_settings(settings_path: str, data: dict, data_folder: str) -> None:
+    """Write settings for Reality Mesh processing.
+
+    Ensures ``data_folder`` exists and sets it as ``source_Directory`` while
+    also adding a ``[BiSimOneClickPath]`` section.
+    """
+
     defaults = OrderedDict([
         ("orthocam_Resolution", "0.05"),
         ("orthocam_Render_Lowest", "1"),
@@ -84,6 +90,7 @@ def write_project_settings(settings_path: str, data: dict, data_folder: str) -> 
 
     settings = OrderedDict()
     settings['project_name'] = f"{project_name} ({timestamp})"
+    os.makedirs(data_folder, exist_ok=True)
     settings['source_Directory'] = data_folder
     settings['offset_coordsys'] = _parse_offset_coordsys(wkt) + '(centerpointoforigin)'
     settings['offset_hdatum'] = 'WGS84'
@@ -96,6 +103,8 @@ def write_project_settings(settings_path: str, data: dict, data_folder: str) -> 
     with open(settings_path, 'w', encoding='utf-8') as f:
         for key, value in settings.items():
             f.write(f"{key}={value}\n")
+        f.write("\n[BiSimOneClickPath]\n")
+        f.write(f"path={data_folder}\n")
     print(f"Wrote settings file {settings_path}")
 
 


### PR DESCRIPTION
## Summary
- timestamp project folders regardless of dataset root
- ensure source_Directory folder exists and add `[BiSimOneClickPath]` section
- replicate settings writer changes across toolkit utilities

## Testing
- `python -m py_compile PythonPorjects/post_process_utils.py PythonPorjects/STE_Toolkit.py PythonPorjects/reality_mesh_gui.py PythonPorjects/reality_mesh_monitor.py`


------
https://chatgpt.com/codex/tasks/task_e_68822f4be2ac83228e8d9f4d8c0688f2

## Summary by Sourcery

Standardize and enhance Reality Mesh utilities by unifying timestamped project folder creation, ensuring data subfolder availability, adding a BiSimOneClickPath section to settings files, and introducing a standalone post_process_utils module for end-to-end project post-processing.

New Features:
- Add a [BiSimOneClickPath] section to settings writers in STE_Toolkit, reality_mesh_gui, and reality_mesh_monitor to record the data_folder path
- Introduce a new post_process_utils module providing project structure creation, OBJ copying, center-pivot JSON parsing, settings file generation, PowerShell execution, and result distribution

Enhancements:
- Standardize project folder creation to always include a timestamp under dataset_root or build_dir and ensure a ‘data’ subdirectory
- Guarantee the data_folder exists before writing settings and use it as the source_Directory in all utilities