### PR TITLE
Enhance project naming and dataset setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,11 @@ python PythonPorjects/RealityMeshStandalone.py
 
 Avoid hard‑coded absolute paths so the tool can be executed from any checkout location.
 The required `RealityMeshProcess.ps1` script and `RealityMeshSystemSettings.txt` file
-are bundled under `PythonPorjects/photomesh`. The GUI automatically points to these
-files so the user only needs to browse to the `Build_1/out` folder.
+are bundled under `PythonPorjects/photomesh`. The GUI automatically points to
+these files so the user only needs to browse to the `Build_1/out` folder. When
+starting the process you will be asked for a **project name**. This name is
+used for the resulting dataset and ensures each run is created in a unique
+folder.
 
 ### Configuring Tool Paths
 
@@ -42,8 +45,9 @@ terratools_home_path=C:\Program Files\Bohemia Interactive Simulations\TerraTools
 dataset_root=C:\BiSim OneClick\Datasets
 ```
 
-`dataset_root` specifies where new project folders are created before
-running the Reality Mesh process.
+`dataset_root` specifies where new project folders are created before running
+the Reality Mesh process. The folder will be created automatically the first
+time the tool runs if it does not already exist.
 
 Adjust these paths if your installers reside elsewhere or you need to reference
 additional tools like ModelExchanger.

--- a/RealityMeshSystemSettings.txt
+++ b/RealityMeshSystemSettings.txt
@@ -7,3 +7,5 @@ override_Installation_DevSuite=0
 override_Path_DevSuite=P
 terratools_ssh_path=C:\Program Files\Bohemia Interactive Simulations\TerraTools\bin\terratoolssh.exe
 terratools_home_path=C:\Program Files\Bohemia Interactive Simulations\TerraTools
+
+dataset_root=C:\BiSim OneClick\Datasets


### PR DESCRIPTION
## Summary
- prompt for a project name in the GUI
- ensure the dataset root path exists on startup
- validate PowerShell script path before running
- document new project name requirement and dataset root behavior
- add dataset_root entry to `RealityMeshSystemSettings.txt`

## Testing
- `python -m py_compile PythonPorjects/reality_mesh_gui.py`
- `python -m py_compile PythonPorjects/RealityMeshStandalone.py PythonPorjects/STE_Toolkit.py PythonPorjects/custom_launcher.py PythonPorjects/get_exe_version.py PythonPorjects/post_process_utils.py PythonPorjects/reality_mesh_monitor.py`


------
https://chatgpt.com/codex/tasks/task_e_6882394947cc83228d432f22084d7e25

## Summary by Sourcery

Enhance the GUI to require a project name, validate the PowerShell script path before running, ensure the dataset root directory exists on startup, and update documentation and settings to support these behaviors

New Features:
- Add GUI prompt for project name and enforce input before processing

Enhancements:
- Validate the existence of the PowerShell script before execution
- Auto-create the dataset root directory on startup based on system settings
- Add dataset_root setting to the system settings file

Documentation:
- Update README to document project name requirement and automatic dataset root creation