### PR TITLE
Sync VBS4 path with config

### DIFF
--- a/PythonPorjects/photomesh/RealityMeshSystemSettings.txt
+++ b/PythonPorjects/photomesh/RealityMeshSystemSettings.txt
@@ -1,8 +1,9 @@
 blender_path=C:\Program Files\Blender Foundation\Blender 4.5\blender.exe
 blender_threads=6
 override_Installation_VBS4=1
-override_Path_VBS4=C:\Bohemia Interactive Simulations\VBS4 24.2 YYMEA_General
-vbs4_version=VBS4_24_2
+# Path and version are automatically updated by the toolkit
+override_Path_VBS4=
+vbs4_version=
 override_Installation_DevSuite=0
 override_Path_DevSuite=P
 terratools_ssh_path=C:\Program Files\Bohemia Interactive Simulations\TerraTools\bin\terratoolssh.exe

--- a/PythonPorjects/photomesh/SetupSystemSettingsREADME.txt
+++ b/PythonPorjects/photomesh/SetupSystemSettingsREADME.txt
@@ -1,11 +1,15 @@
-You will need to create a text file in this folder named RealityMeshSystemSettings.txt.  In it you will include the contents below, adjusted after the = signs to point to the appropriate values on your machine.
-These are just example values, you will want to configure everything to your specific machine.  This only needs created once.  The items below should be all that is in the file.  To note, 1 = true, 0 = false
+Create a text file in this folder named ``RealityMeshSystemSettings.txt``. The
+VBS4 path no longer needs to be edited manually – it will be updated
+automatically based on the toolkit configuration.  The remaining values are
+examples that can be tailored to your machine.  This file only needs to be
+created once.  To note, ``1`` = true, ``0`` = false.
 
 blender_path=C:\Program Files\Blender Foundation\Blender 4.5\blender.exe
 blender_threads=6
 override_Installation_VBS4=1
-override_Path_VBS4=F:\VBS4_24_2
-vbs4_version=VBS4_24_2
+# Path and version are injected automatically when the scripts run
+override_Path_VBS4=
+vbs4_version=
 override_Installation_DevSuite=0
 override_Path_DevSuite=P
 terratools_ssh_path=C:\Program Files\Bohemia Interactive Simulations\TerraTools\bin\terratoolssh.exe

--- a/RealityMeshSystemSettings.txt
+++ b/RealityMeshSystemSettings.txt
@@ -1,8 +1,9 @@
 blender_path=C:\Program Files\Blender Foundation\Blender 4.5\blender.exe
 blender_threads=6
 override_Installation_VBS4=1
-override_Path_VBS4=F:\VBS4_24_2
-vbs4_version=VBS4_24_2
+# Path and version are automatically updated by the toolkit
+override_Path_VBS4=
+vbs4_version=
 override_Installation_DevSuite=0
 override_Path_DevSuite=P
 terratools_ssh_path=C:\Program Files\Bohemia Interactive Simulations\TerraTools\bin\terratoolssh.exe


### PR DESCRIPTION
## Summary
- auto-update VBS4 path in RealityMesh settings using the configured installation
- update system settings files to use auto-injected VBS4 path
- ensure path update runs in STE_Toolkit, reality_mesh_gui and monitor scripts
- document that the path is set automatically

## Testing
- `python -m py_compile PythonPorjects/*.py`

------
https://chatgpt.com/codex/tasks/task_e_68824743f00c8322a5eadf4d5aff6b25