### PR TITLE
Improve project folder selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ python PythonPorjects/RealityMeshStandalone.py
 Avoid hard‑coded absolute paths so the tool can be executed from any checkout location.
 The required `RealityMeshProcess.ps1` script and `RealityMeshSystemSettings.txt` file
 are bundled under `PythonPorjects/photomesh`. The GUI automatically points to
-these files so the user only needs to browse to the `Build_1/out` folder.
+these files so the user only needs to browse to the PhotoMesh project folder.
 
 ### Configuring Tool Paths
 


### PR DESCRIPTION
## Summary
- allow selecting the PhotoMesh project root rather than Build_1/out
- recursively find `Output-CenterPivotOrigin.json` under the selected folder
- update the GUI texts to mention project directory
- update docs to describe new selection behavior

## Testing
- `python -m py_compile PythonPorjects/reality_mesh_gui.py`
- `find PythonPorjects -name '*.py' -print0 | xargs -0 python -m py_compile`

------
https://chatgpt.com/codex/tasks/task_e_68824a4171748322b9c60f9f28fb01d6