### PR TITLE
Add one-click output path setting

### DIFF
--- a/PythonPorjects/config.ini
+++ b/PythonPorjects/config.ini
@@ -21,5 +21,8 @@ config_path = fuser_config.json
 local_fuser_exe = C:\\Program Files\\Skyline\\PhotoMesh\\Fuser\\PhotoMeshFuser.exe
 remote_fuser_exe = C:\\Program Files\\Skyline\\PhotoMesh\\Fuser\\PhotoMeshFuser.exe
 fuser_computer = False
-working_folder_host = 
+working_folder_host =
+
+[BiSimOneClickPath]
+path =
 

--- a/README.md
+++ b/README.md
@@ -46,5 +46,10 @@ dataset_root=C:\BiSim OneClick\Datasets
 the Reality Mesh process. The folder will be created automatically the first
 time the tool runs if it does not already exist.
 
+Once a project is processed, the toolkit saves the full path to the generated
+dataset under a `[BiSimOneClickPath]` section in `config.ini`. The Settings
+panel now exposes this path and allows manually browsing for a different
+output folder.
+
 Adjust these paths if your installers reside elsewhere or you need to reference
 additional tools like ModelExchanger.


### PR DESCRIPTION
## Summary
- display the one‑click dataset path in Settings and allow editing it
- store the path under `[BiSimOneClickPath]` in `config.ini`
- update the path after each project is processed
- document the new behaviour in the README

## Testing
- `python -m py_compile PythonPorjects/STE_Toolkit.py`

------
https://chatgpt.com/codex/tasks/task_e_68824d3aa3a88322b192c24ea9d40d7d

## Summary by Sourcery

Enable users to set, view, and persist the One-Click dataset output folder via the Settings panel and update the config file accordingly.

New Features:
- Add Settings panel UI to display and browse the One-Click output folder
- Persist the One-Click dataset output path in config.ini under [BiSimOneClickPath]
- Automatically update the stored output path after each project run

Documentation:
- Document the new One-Click output path setting and behavior in the README