### PR TITLE
Fix project name from build path

### DIFF
--- a/PythonPorjects/reality_mesh_gui.py
+++ b/PythonPorjects/reality_mesh_gui.py
@@ -383,7 +383,13 @@ class RealityMeshGUI(tk.Tk):
 
             with open(json_path, 'r', encoding='utf-8') as f:
                 data = json.load(f)
-            project_name = data.get('project_name', 'project')
+
+            # Extract project name from the selected path if possible
+            match = re.search(r'\\Projects\\([^\\]+)', build_root, re.IGNORECASE)
+            if match:
+                project_name = match.group(1)
+            else:
+                project_name = data.get('project_name', 'project')
 
             sys_set = self.system_settings.get()
             settings = {}


### PR DESCRIPTION
## Summary
- ensure Reality Mesh uses project name from the selected path

## Testing
- `find PythonPorjects -name '*.py' -print | xargs -I{} python -m py_compile {} && echo OK`

------
https://chatgpt.com/codex/tasks/task_e_688252f0d5a083228013c87f0ed56a33

## Summary by Sourcery

Extract the project name from the selected build path when available, falling back to the JSON value or a default

Bug Fixes:
- Derive project_name from the build path using a regex to match the Projects directory
- Fallback to the existing JSON project_name or 'project' if no path match is found