### PR TITLE
Fix settings file naming

### DIFF
--- a/PythonPorjects/STE_Toolkit.py
+++ b/PythonPorjects/STE_Toolkit.py
@@ -2658,7 +2658,9 @@ class VBS4Panel(tk.Frame):
             copy_tiles(self.last_build_dir, data_folder)
             self.log_message("Copied raw tiles")
 
-            settings_path = os.path.join(proj_folder, f'{project_name}.txt')
+            # Use a consistent naming pattern for the project settings file
+            # when creating project folders during post processing
+            settings_path = os.path.join(proj_folder, f'{project_name}-settings.txt')
             write_project_settings(settings_path, data, data_folder)
             self.log_message(f"Wrote settings {settings_path}")
 

--- a/PythonPorjects/post_process_utils.py
+++ b/PythonPorjects/post_process_utils.py
@@ -53,7 +53,8 @@ def create_settings_file(info: dict, project_folder: str) -> str:
     for both the ``source_Directory`` value and a ``[BiSimOneClickPath]``
     section.
     """
-    settings_path = os.path.join(project_folder, f"{info['project_name']}.txt")
+    # Name the settings file using the conventional "<project>-settings.txt"
+    settings_path = os.path.join(project_folder, f"{info['project_name']}-settings.txt")
     dataset_root = os.path.join('C:\\BiSim OneClick\\Datasets', info['project_name'])
     dataset_data = os.path.join(dataset_root, 'data')
     os.makedirs(dataset_data, exist_ok=True)

--- a/PythonPorjects/reality_mesh_gui.py
+++ b/PythonPorjects/reality_mesh_gui.py
@@ -404,7 +404,8 @@ class RealityMeshGUI(tk.Tk):
             copy_tiles(build_dir, data_folder)
             self.log_msg('Copied raw tiles')
 
-            settings_path = os.path.join(proj_folder, f'{project_name}.txt')
+            # Save the per-project settings using the "<name>-settings.txt" pattern
+            settings_path = os.path.join(proj_folder, f'{project_name}-settings.txt')
             write_project_settings(settings_path, data, data_folder)
             self.log_msg(f'Wrote settings {settings_path}')
 


### PR DESCRIPTION
## Summary
- keep dataset settings file naming consistent

## Testing
- `python -m py_compile PythonPorjects/STE_Toolkit.py PythonPorjects/post_process_utils.py PythonPorjects/reality_mesh_gui.py`

------
https://chatgpt.com/codex/tasks/task_e_6882548c4b808322b67f8d6ae51df59a