### PR TITLE
Hide terrain options during post-processing

### DIFF
--- a/PythonPorjects/STE_Toolkit.py
+++ b/PythonPorjects/STE_Toolkit.py
@@ -2658,6 +2658,11 @@ class VBS4Panel(tk.Frame):
         self.log_message("One-Click Terrain Conversion completed.")
 
     def post_process_last_build(self):
+        # Hide the terrain options if they are currently visible so the
+        # progress bar remains unobstructed during processing.
+        if self.terrain_button.cget("text") == "Hide Terrain Options":
+            self.toggle_terrain_buttons()
+
         if not self.last_build_dir:
             path = filedialog.askdirectory(title="Select PhotoMesh Project Folder", parent=self)
             if not path:


### PR DESCRIPTION
## Summary
- hide terrain options when starting post-processing so progress bar is visible

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68827839d4e883228e53432b67b2a6cc

## Summary by Sourcery

Enhancements:
- Toggle off terrain options in post_process_last_build if they are currently displayed