### PR TITLE
Default project browse location

### DIFF
--- a/PythonPorjects/STE_Toolkit.py
+++ b/PythonPorjects/STE_Toolkit.py
@@ -2663,8 +2663,17 @@ class VBS4Panel(tk.Frame):
         if self.terrain_button.cget("text") == "Hide Terrain Options":
             self.toggle_terrain_buttons()
 
+        sys_settings_path = os.path.join(BASE_DIR, 'photomesh', 'RealityMeshSystemSettings.txt')
+        dataset_root = ''
+        try:
+            settings = load_system_settings(sys_settings_path)
+            dataset_root = settings.get('dataset_root', '')
+        except Exception:
+            pass
+
         if not self.last_build_dir:
-            path = filedialog.askdirectory(title="Select PhotoMesh Project Folder", parent=self)
+            path = filedialog.askdirectory(title="Select PhotoMesh Project Folder", parent=self,
+                                           initialdir=dataset_root or None)
             if not path:
                 return
             self.last_build_dir = path

--- a/PythonPorjects/reality_mesh_gui.py
+++ b/PythonPorjects/reality_mesh_gui.py
@@ -288,6 +288,7 @@ class RealityMeshGUI(tk.Tk):
         default_settings = os.path.join(photomesh_dir, 'RealityMeshSystemSettings.txt')
         default_ps = os.path.join(photomesh_dir, 'RealityMeshProcess.ps1')
 
+        self.dataset_root = ''
         if os.path.isfile(default_settings) and not self.system_settings.get():
             self.system_settings.set(default_settings)
             try:
@@ -295,6 +296,7 @@ class RealityMeshGUI(tk.Tk):
                 settings = load_system_settings(default_settings)
                 ds_root = settings.get('dataset_root')
                 if ds_root:
+                    self.dataset_root = ds_root
                     os.makedirs(ds_root, exist_ok=True)
             except OSError:
                 pass
@@ -367,7 +369,7 @@ class RealityMeshGUI(tk.Tk):
         self.progress_label.grid(row=row, column=0, columnspan=3, sticky='e', padx=5)
 
     def browse_build(self):
-        path = filedialog.askdirectory()
+        path = filedialog.askdirectory(initialdir=self.dataset_root or None)
         if path:
             self.build_dir.set(path)
 


### PR DESCRIPTION
## Summary
- remember the dataset root path from the system settings
- use that path as the starting location when selecting a PhotoMesh project

## Testing
- `python -m py_compile PythonPorjects/reality_mesh_gui.py PythonPorjects/STE_Toolkit.py`

------
https://chatgpt.com/codex/tasks/task_e_68827ee900548322b801f509809e2df6

## Summary by Sourcery

Load the dataset root path from RealityMeshSystemSettings.txt and use it as the default initial directory in project and build folder selection dialogs

Enhancements:
- Read and store the 'dataset_root' setting from the system settings file
- Pass the stored dataset_root as the initialdir in filedialog.askdirectory for project and build folder selection