### PR TITLE
Fix escape sequence warnings

### DIFF
--- a/PythonPorjects/STE_Toolkit.py
+++ b/PythonPorjects/STE_Toolkit.py
@@ -2417,7 +2417,11 @@ class VBS4Panel(tk.Frame):
         folder_window.wait_window()
 
     def prompt_remote_fuser_details(self, ip):
-        remote_path = simpledialog.askstring("Remote Folder Path", f"Enter shared folder path on {ip} (e.g., \{ip}\SharedMeshDrive\WorkingFuser):", parent=self)
+        remote_path = simpledialog.askstring(
+            "Remote Folder Path",
+            fr"Enter shared folder path on {ip} (e.g., \\{ip}\SharedMeshDrive\WorkingFuser):",
+            parent=self,
+        )
         fuser_name = simpledialog.askstring("Fuser Name", f"Enter unique fuser name for {ip}:", parent=self)
         return remote_path, fuser_name
 

--- a/PythonPorjects/post_process_utils.py
+++ b/PythonPorjects/post_process_utils.py
@@ -47,7 +47,7 @@ def parse_centerpivot_json(json_path: str, project_name: str) -> dict:
 
 
 def create_settings_file(info: dict, project_folder: str) -> str:
-    """Write the Reality Mesh settings file using *info*.
+    r"""Write the Reality Mesh settings file using *info*.
 
     A matching folder is created under ``C:\BiSim OneClick\Datasets`` and used
     for both the ``source_Directory`` value and a ``[BiSimOneClickPath]``


### PR DESCRIPTION
## Summary
- escape backslashes in shared path prompt
- mark docstring as raw to avoid escape warnings

## Testing
- `PYTHONWARNINGS=error python -m py_compile PythonPorjects/*.py`

------
https://chatgpt.com/codex/tasks/task_e_6888cecc5e6483229f71c15e5a4370b1