### PR TITLE
Fix RealityMeshProcess template path

### DIFF
--- a/PythonPorjects/photomesh/RealityMeshProcess.ps1
+++ b/PythonPorjects/photomesh/RealityMeshProcess.ps1
@@ -220,7 +220,19 @@ if ($AREYOUSURE -eq 'y') {
 	
 	$command_path = "..\..\ProjectSettings\GeneratedFiles_DoNotEdit\$project_name.txt"
 
-	robocopy RealityMesh_tt "Projects\$project_name"
+        # Copy the project template files from the repository location.
+        # Previously this expected the template folder to exist under the STE
+        # Toolkit installation directory.  Use the template bundled with this
+        # script instead to avoid relying on a fixed install path.
+        $templatePath = Join-Path $PSScriptRoot 'RealityMesh_tt'
+        $destinationPath = Join-Path $PSScriptRoot "Projects\$project_name"
+        if (Test-Path $templatePath) {
+                robocopy $templatePath $destinationPath
+        }
+        else {
+                Write-Output "Template folder not found at $templatePath"
+                Return
+        }
 	
 	Set-Location -Path "$PSScriptRoot\Projects\$project_name"
 	


### PR DESCRIPTION
## Summary
- copy project template from script directory
- exit early if template folder missing

## Testing
- `pwsh -NoProfile -Command "$PSVersionTable.PSVersion"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6888d9f4a7c083228f814eabb9a81e48