### PR TITLE
Fix numeric offsets in project settings

### DIFF
--- a/PythonPorjects/STE_Toolkit.py
+++ b/PythonPorjects/STE_Toolkit.py
@@ -18,6 +18,7 @@ import re
 import socket
 import threading
 import shlex
+from post_process_utils import clean_project_settings
 from collections import OrderedDict
 import time
 import glob
@@ -2714,6 +2715,8 @@ class VBS4Panel(tk.Frame):
             settings_path = os.path.join(proj_folder, f'{project_name}-settings.txt')
             write_project_settings(settings_path, data, data_folder)
             self.log_message(f"Wrote settings {settings_path}")
+            settings_path = clean_project_settings(settings_path)
+            self.log_message("Cleaned offset values")
 
             set_oneclick_output_path(proj_folder)
             self.controller.panels['Settings'].update_oneclick_path_label()

--- a/PythonPorjects/reality_mesh_gui.py
+++ b/PythonPorjects/reality_mesh_gui.py
@@ -15,6 +15,7 @@ from STE_Toolkit import (
     get_vbs4_version,
     distribute_terrain,
 )
+from post_process_utils import clean_project_settings
 
 
 def load_system_settings(path: str) -> dict:
@@ -439,6 +440,8 @@ class RealityMeshGUI(tk.Tk):
             settings_path = os.path.join(proj_folder, f'{project_name}-settings.txt')
             write_project_settings(settings_path, data, data_folder)
             self.log_msg(f'Wrote settings {settings_path}')
+            settings_path = clean_project_settings(settings_path)
+            self.log_msg('Cleaned offset values')
 
             run_processor(
                 self.ps_script.get(),

--- a/PythonPorjects/reality_mesh_monitor.py
+++ b/PythonPorjects/reality_mesh_monitor.py
@@ -7,6 +7,7 @@ import subprocess
 from datetime import datetime
 from collections import OrderedDict
 from STE_Toolkit import get_vbs4_install_path, get_vbs4_version
+from post_process_utils import clean_project_settings
 
 
 def load_system_settings(path: str) -> dict:
@@ -178,6 +179,8 @@ def main() -> None:
     settings_filename = f"{project_name}_build1_{dt_str}.txt"
     settings_path = os.path.join(project_dir, settings_filename)
     write_project_settings(settings_path, data, data_folder)
+
+    settings_path = clean_project_settings(settings_path)
 
     run_processor(args.ps_script, settings_path)
 


### PR DESCRIPTION
## Summary
- sanitize offset values in project settings files
- clean settings before running the post‑process pipeline

## Testing
- `python -m py_compile PythonPorjects/post_process_utils.py PythonPorjects/reality_mesh_gui.py PythonPorjects/reality_mesh_monitor.py PythonPorjects/STE_Toolkit.py`

------
https://chatgpt.com/codex/tasks/task_e_6888f5c923c48322936625e24f63456e