### PR TITLE
Add parameterized TCL launch script

### DIFF
--- a/PythonPorjects/photomesh/RunRealityMeshTcl.ps1
+++ b/PythonPorjects/photomesh/RunRealityMeshTcl.ps1
@@ -1,0 +1,27 @@
+# PowerShell script to run RealityMeshProcess.tcl without hard-coded paths
+param(
+    [Parameter(Mandatory=$true, Position=0)]
+    [string]$SettingsFile
+)
+
+# Path to RealityMeshProcess.tcl relative to this script
+$tclScript = Join-Path $PSScriptRoot "RealityMesh_tt\RealityMeshProcess.tcl"
+
+# Directory containing the TCL script
+$tclWorkingDir = Split-Path $tclScript
+
+# Validate that the settings file exists
+if (-not (Test-Path $SettingsFile)) {
+    Write-Error "Settings file not found: $SettingsFile"
+    exit 1
+}
+
+Write-Host "Launching RealityMeshProcess.tcl with settings from $SettingsFile" -ForegroundColor Cyan
+
+# Execute the TCL script using tclsh within the correct working directory
+Push-Location $tclWorkingDir
+try {
+    & tclsh $tclScript -command_file "$SettingsFile"
+} finally {
+    Pop-Location
+}


### PR DESCRIPTION
## Summary
- refactor `RunRealityMeshTcl.ps1` to avoid hard-coded paths
- script now accepts the settings file as an argument and resolves the TCL path relative to its own location

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_688907be4b4c8322a46bcc82e6a7ee00