### PR TITLE
Add wait message before running RealityMeshProcess.tcl

### DIFF
--- a/PythonPorjects/photomesh/RunRealityMeshTcl.ps1
+++ b/PythonPorjects/photomesh/RunRealityMeshTcl.ps1
@@ -21,6 +21,8 @@ Write-Host "Launching RealityMeshProcess.tcl with settings from $SettingsFile" -
 # Execute the TCL script using tclsh within the correct working directory
 Push-Location $tclWorkingDir
 try {
+    Write-Host "🚧 Processing Reality Mesh... Please wait. Do not close this window." -ForegroundColor Yellow
+    Start-Sleep -Seconds 2
     & tclsh $tclScript -command_file "$SettingsFile"
 } finally {
     Pop-Location


### PR DESCRIPTION
## Summary
- show a clear processing notice when `RunRealityMeshTcl.ps1` launches the TCL script
- give the user two seconds to read the message before the script proceeds

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688911c04e7883229d7b35b5ed25084f

## Summary by Sourcery

Add a pre-execution notice and pause to the PowerShell launcher for the TCL script

Enhancements:
- Display a yellow "Processing Reality Mesh... Please wait. Do not close this window." message before running the TCL script
- Pause for 2 seconds to give the user time to read the notice