### PR TITLE
Check for n33.tbr before running RealityMeshProcess

### DIFF
--- a/PythonPorjects/photomesh/RunRealityMeshTcl.ps1
+++ b/PythonPorjects/photomesh/RunRealityMeshTcl.ps1
@@ -16,11 +16,21 @@ if (-not (Test-Path $SettingsFile)) {
     exit 1
 }
 
-Write-Host "Launching RealityMeshProcess.tcl with settings from $SettingsFile" -ForegroundColor Cyan
-
-# Execute the TCL script using tclsh within the correct working directory
+# Ensure n33.tbr is present before running the main TCL script
 Push-Location $tclWorkingDir
 try {
+    $n33File = "n33.tbr"
+    if (-not (Test-Path $n33File)) {
+        Write-Host "n33.tbr not found. Generating with TSG_TBR_to_Vertex_Points_Unique.tcl..." -ForegroundColor Yellow
+        & tclsh "TSG_TBR_to_Vertex_Points_Unique.tcl"
+    }
+
+    if (-not (Test-Path $n33File)) {
+        Write-Host "ERROR: Required file n33.tbr could not be created." -ForegroundColor Red
+        exit 1
+    }
+
+    Write-Host "Launching RealityMeshProcess.tcl with settings from $SettingsFile" -ForegroundColor Cyan
     Write-Host "🚧 Processing Reality Mesh... Please wait. Do not close this window." -ForegroundColor Yellow
     Start-Sleep -Seconds 2
     & tclsh $tclScript -command_file "$SettingsFile"


### PR DESCRIPTION
## Summary
- ensure `RunRealityMeshTcl.ps1` checks that `n33.tbr` exists before launching `RealityMeshProcess.tcl`
- generate `n33.tbr` using `TSG_TBR_to_Vertex_Points_Unique.tcl` when missing
- abort with a red error message if `n33.tbr` still isn't found
- run the TCL process only after confirming the file exists

## Testing
- `pwsh` was not available so no script syntax check was run

------
https://chatgpt.com/codex/tasks/task_e_688915be60208322aec3e4af36f13015