### PR TITLE
Fix post-processor GUI launch

### DIFF
--- a/PythonPorjects/STE_Toolkit.py
+++ b/PythonPorjects/STE_Toolkit.py
@@ -2762,7 +2762,8 @@ class VBS4Panel(tk.Frame):
     def open_reality_mesh_gui(self):
         script_dir = os.path.dirname(os.path.abspath(__file__))
         script_path = os.path.join(script_dir, 'RealityMeshStandalone.py')
-        subprocess.Popen(['python', script_path])
+        python_exe = sys.executable if sys.executable else 'python'
+        subprocess.Popen([python_exe, script_path])
 
     def log_message(self, message):
          self.log_text.config(state="normal")


### PR DESCRIPTION
## Summary
- open the standalone post-processor using the current Python interpreter

## Testing
- `python -m py_compile PythonPorjects/STE_Toolkit.py PythonPorjects/RealityMeshStandalone.py PythonPorjects/reality_mesh_gui.py`


------
https://chatgpt.com/codex/tasks/task_e_68891f6e5fd88322aab939f08abdac0b