### PR TITLE
Add remote execution script

### DIFF
--- a/PythonPorjects/photomesh/Invoke-RemoteRealityMesh.ps1
+++ b/PythonPorjects/photomesh/Invoke-RemoteRealityMesh.ps1
@@ -1,0 +1,24 @@
+param(
+    [Parameter(Mandatory=$true, Position=0)]
+    [string]$TargetIP,
+    [Parameter(Mandatory=$true, Position=1)]
+    [string]$SettingsFile
+)
+
+if (-not (Test-Path $SettingsFile)) {
+    Write-Error "Settings file not found: $SettingsFile"
+    exit 1
+}
+
+$session = New-PSSession -ComputerName $TargetIP
+try {
+    $scriptPath = Join-Path $PSScriptRoot 'RealityMeshProcess.ps1'
+    Write-Host "Running RealityMeshProcess.ps1 on $TargetIP" -ForegroundColor Cyan
+    $output = Invoke-Command -Session $session -FilePath $scriptPath -ArgumentList $SettingsFile
+    Write-Output $output
+}
+finally {
+    if ($session) {
+        Remove-PSSession $session
+    }
+}


### PR DESCRIPTION
## Summary
- add `Invoke-RemoteRealityMesh.ps1` to run `RealityMeshProcess.ps1` via PowerShell remoting

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688a2e1a3c708322a86ec75ce3a29385

## Summary by Sourcery

New Features:
- Introduce Invoke-RemoteRealityMesh.ps1 to execute RealityMeshProcess.ps1 remotely via PowerShell remoting