### PR TITLE
Update RealityMesh scripts to use shared drive

### DIFF
--- a/PythonPorjects/photomesh/Invoke-RemoteRealityMesh.ps1
+++ b/PythonPorjects/photomesh/Invoke-RemoteRealityMesh.ps1
@@ -5,16 +5,37 @@ param(
     [string]$SettingsFile
 )
 
+# Shared drive used by both machines
+$sharedRoot = "\\\SharedDrive\PhotoMesh"
+$inputRoot = Join-Path $sharedRoot 'Input'
+
 if (-not (Test-Path $SettingsFile)) {
     Write-Error "Settings file not found: $SettingsFile"
     exit 1
 }
 
+# Read basic info from the local settings file
+$settingsContent = Get-Content $SettingsFile
+$projectName = ($settingsContent | Where-Object { $_ -match '^project_name=' }) -replace 'project_name=', ''
+$sourceDir = ($settingsContent | Where-Object { $_ -match '^source_Directory=' }) -replace 'source_Directory=', ''
+
+$projectInputDir = Join-Path $inputRoot $projectName
+New-Item -ItemType Directory -Path $projectInputDir -Force | Out-Null
+$destDataDir = Join-Path $projectInputDir 'data'
+robocopy $sourceDir $destDataDir /MIR | Out-Null
+
+# Copy and update the settings file on the shared drive
+$remoteSettings = Join-Path $projectInputDir (Split-Path $SettingsFile -Leaf)
+Copy-Item $SettingsFile $remoteSettings -Force
+(Get-Content $remoteSettings) | ForEach-Object {
+    if ($_ -match '^source_Directory=') { "source_Directory=$destDataDir" } else { $_ }
+} | Set-Content $remoteSettings
+
 $session = New-PSSession -ComputerName $TargetIP
 try {
     $scriptPath = Join-Path $PSScriptRoot 'RealityMeshProcess.ps1'
     Write-Host "Running RealityMeshProcess.ps1 on $TargetIP" -ForegroundColor Cyan
-    $output = Invoke-Command -Session $session -FilePath $scriptPath -ArgumentList $SettingsFile
+    $output = Invoke-Command -Session $session -FilePath $scriptPath -ArgumentList $remoteSettings
     Write-Output $output
 }
 finally {


### PR DESCRIPTION
## Summary
- reference a shared drive in RealityMeshProcess.ps1
- write generated settings and outputs to the shared drive
- sync project files and settings to the shared drive before remote execution

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_688a33d085e88322bf54d5e5e2f8f245