### PR TITLE
Add remote processing capability

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,3 +54,12 @@ output folder.
 
 Adjust these paths if your installers reside elsewhere or you need to reference
 additional tools like ModelExchanger.
+
+### Remote Processing
+
+Enter the destination workstation's IP address in the **Remote Host** field of
+the GUI to offload processing. When a remote host is provided the toolkit calls
+`Invoke-RemoteRealityMesh.ps1` which launches `RealityMeshProcess.ps1` on the
+remote machine and copies the finished dataset back to the results folder.
+The "Post-Process Last Build" button prompts for a remote host similarly when
+launched from the main STE Toolkit.


### PR DESCRIPTION
## Summary
- enable remote Reality Mesh processing from the GUI and toolkit main menu
- prompt for remote host when post-processing a build from STE_Toolkit
- document the new option in README

## Testing
- `python -m py_compile PythonPorjects/reality_mesh_gui.py PythonPorjects/post_process_utils.py PythonPorjects/STE_Toolkit.py`

------
https://chatgpt.com/codex/tasks/task_e_688a3d5535b883228919594b75325c45

## Summary by Sourcery

Add the ability to offload Reality Mesh post-processing to a remote machine via new PowerShell invocation scripts and a Remote Host option.

New Features:
- Introduce run_remote_processor in both STE_Toolkit and GUI to execute the processing script on a specified remote host with live progress feedback
- Add an optional Remote Host field in the GUI and a prompt in STE_Toolkit’s post-process workflow to specify the target IP or hostname
- Extend processing logic to choose between local and remote execution based on the presence of a Remote Host entry

Documentation:
- Document the remote processing workflow and new Invoke-RemoteRealityMesh.ps1 usage in README