### PR TITLE
Show status in Reality Mesh PowerShell scripts

### DIFF
--- a/PythonPorjects/photomesh/RealityMeshProcess.ps1
+++ b/PythonPorjects/photomesh/RealityMeshProcess.ps1
@@ -281,11 +281,20 @@ if ($AREYOUSURE -eq 'y') {
         Write-Host "Launching RealityMeshProcess.tcl with settings from $command_path" -ForegroundColor Cyan
         Write-Host "🚧 Processing Reality Mesh... Please wait. Do not close this window." -ForegroundColor Yellow
         Start-Sleep -Seconds 2
-        $time = Measure-Command {
-                #& "$terratools_ssh_path" OneClick.tcl -command_file "$command_path"
-                Start-Process -FilePath "$terratools_ssh_path" -Wait -NoNewWindow -ArgumentList "RealityMeshProcess.tcl -command_file `"$command_path`""
+
+        $startTime = Get-Date
+        $proc = Start-Process -FilePath "$terratools_ssh_path" -NoNewWindow -PassThru -ArgumentList "RealityMeshProcess.tcl -command_file `"$command_path`""
+        $spinner = '/-\|'
+        $i = 0
+        while (-not $proc.HasExited) {
+                $char = $spinner[$i % $spinner.Length]
+                Write-Host -NoNewline "`r$char Processing..."
+                Start-Sleep -Seconds 1
+                $i++
         }
-	
+        $proc.WaitForExit()
+        Write-Host "`rProcessing complete.             "
+        $time = (Get-Date) - $startTime
         $minutes = $time.TotalSeconds / 60
         Write-Output "`nTime to run TT project: $minutes minutes"
 

--- a/PythonPorjects/photomesh/RunRealityMeshTcl.ps1
+++ b/PythonPorjects/photomesh/RunRealityMeshTcl.ps1
@@ -33,7 +33,18 @@ try {
     Write-Host "Launching RealityMeshProcess.tcl with settings from $SettingsFile" -ForegroundColor Cyan
     Write-Host "🚧 Processing Reality Mesh... Please wait. Do not close this window." -ForegroundColor Yellow
     Start-Sleep -Seconds 2
-    & tclsh $tclScript -command_file "$SettingsFile"
+
+    $proc = Start-Process tclsh -ArgumentList "`"$tclScript`" -command_file `"$SettingsFile`"" -NoNewWindow -PassThru
+    $spinner = '/-\|'
+    $i = 0
+    while (-not $proc.HasExited) {
+        $char = $spinner[$i % $spinner.Length]
+        Write-Host -NoNewline "`r$char Processing..."
+        Start-Sleep -Seconds 1
+        $i++
+    }
+    $proc.WaitForExit()
+    Write-Host "`rProcessing complete.             "
 } finally {
     Pop-Location
 }


### PR DESCRIPTION
## Summary
- add a spinner progress display to `RealityMeshProcess.ps1`
- show spinner when running `RunRealityMeshTcl.ps1`

## Testing
- `python - <<'EOF'
import sys, py_compile, pathlib
for path in pathlib.Path('.').rglob('*.py'):
    try:
        py_compile.compile(str(path), doraise=True)
    except Exception as e:
        print(e)
        sys.exit(1)
print('Python compilation OK')
EOF`

------
https://chatgpt.com/codex/tasks/task_e_688a615f668483229f79329f8c9503cb