### PR TITLE
Add visible status window for remote processing

### DIFF
--- a/PythonPorjects/photomesh/Invoke-RemoteRealityMesh.ps1
+++ b/PythonPorjects/photomesh/Invoke-RemoteRealityMesh.ps1
@@ -40,7 +40,10 @@ try {
     Write-Host "Launching RealityMeshProcess.ps1 on $TargetIP" -ForegroundColor Cyan
     Invoke-Command -Session $session -ScriptBlock {
         param($script, $settings)
-        Start-Process powershell -ArgumentList "-ExecutionPolicy Bypass -File `\"$script`\" `\"$settings`\"" -NoNewWindow
+        # Show a visible command window on the remote machine with a status
+        # message so users know processing is running.
+        $args = "/c start cmd /k \"echo RealityMeshProcess in progress do not turn off pc && powershell -ExecutionPolicy Bypass -File `"$script`" `"$settings`"\""
+        Start-Process -FilePath cmd.exe -ArgumentList $args
     } -ArgumentList $scriptPath, $remoteSettings
 }
 finally {

--- a/README.md
+++ b/README.md
@@ -61,5 +61,7 @@ Enter the destination workstation's IP address in the **Remote Host** field of
 the GUI to offload processing. When a remote host is provided the toolkit calls
 `Invoke-RemoteRealityMesh.ps1` which launches `RealityMeshProcess.ps1` on the
 remote machine and copies the finished dataset back to the results folder.
-The "Post-Process Last Build" button prompts for a remote host similarly when
-launched from the main STE Toolkit.
+While running remotely a visible command window pops up on the target machine
+stating `RealityMeshProcess in progress do not turn off pc` to indicate that the
+script is executing. The "Post-Process Last Build" button prompts for a remote
+host similarly when launched from the main STE Toolkit.


### PR DESCRIPTION
## Summary
- show a remote command window when launching RealityMeshProcess so users know processing is running
- document the new status window behaviour in the remote processing section

## Testing
- `python -m py_compile $(git ls-files 'PythonPorjects/*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688a63e6515883228215f382677c858e

## Summary by Sourcery

Add a visible status window for remote RealityMeshProcess runs and update documentation to describe this behavior

New Features:
- Show a visible command window on the remote machine with a status message during RealityMeshProcess execution

Documentation:
- Document the new remote status window behavior in the README