### PR TITLE
Fix launching standalone Reality Mesh GUI

### DIFF
--- a/PythonPorjects/STE_Toolkit.py
+++ b/PythonPorjects/STE_Toolkit.py
@@ -2817,7 +2817,20 @@ class VBS4Panel(tk.Frame):
     def open_reality_mesh_gui(self):
         script_dir = os.path.dirname(os.path.abspath(__file__))
         script_path = os.path.join(script_dir, 'RealityMeshStandalone.py')
-        python_exe = sys.executable if sys.executable else 'python'
+
+        # When running from a PyInstaller build, sys.executable points to the
+        # bundled executable rather than the Python interpreter. Launching the
+        # script with this path would simply reopen the current application.
+        if getattr(sys, 'frozen', False):
+            exe_path = os.path.join(os.path.dirname(sys.executable),
+                                   'RealityMeshStandalone.exe')
+            if os.path.exists(exe_path):
+                subprocess.Popen([exe_path])
+                return
+            python_exe = 'python'
+        else:
+            python_exe = sys.executable if sys.executable else 'python'
+
         subprocess.Popen([python_exe, script_path])
 
     def log_message(self, message):

--- a/README.md
+++ b/README.md
@@ -25,6 +25,11 @@ Launch it from the repository root with:
 python PythonPorjects/RealityMeshStandalone.py
 ```
 
+When running a packaged release created with PyInstaller, a
+`RealityMeshStandalone.exe` is located next to the main toolkit
+executable. The "Open Standalone Post-Processor" button now looks for
+this executable and launches it when available.
+
 Avoid hard‑coded absolute paths so the tool can be executed from any checkout location.
 The required `RealityMeshProcess.ps1` script and `RealityMeshSystemSettings.txt` file
 are bundled under `PythonPorjects/photomesh`. The GUI automatically points to


### PR DESCRIPTION
## Summary
- ensure the STE toolkit can launch the standalone post-processor when built with PyInstaller
- document location of `RealityMeshStandalone.exe` in packaged releases

## Testing
- `python -m py_compile PythonPorjects/STE_Toolkit.py PythonPorjects/RealityMeshStandalone.py PythonPorjects/reality_mesh_gui.py`


------
https://chatgpt.com/codex/tasks/task_e_688a658441c083229612237501d23566

## Summary by Sourcery

Enable the STE toolkit to launch the standalone Reality Mesh GUI from both source and PyInstaller-packaged builds and update documentation accordingly.

Enhancements:
- Detect PyInstaller 'frozen' state and launch RealityMeshStandalone.exe if present, otherwise fall back to the Python script

Documentation:
- Document the location and launch behavior of RealityMeshStandalone.exe in the README