### PR TITLE
Fix dataset_root path normalization

### DIFF
--- a/PythonPorjects/STE_Toolkit.py
+++ b/PythonPorjects/STE_Toolkit.py
@@ -315,7 +315,10 @@ def load_system_settings(path: str) -> dict:
                 if not line or line.startswith('#') or '=' not in line:
                     continue
                 key, value = line.split('=', 1)
-                settings[key.strip()] = value.strip()
+                value = value.strip()
+                if key.strip() == 'dataset_root':
+                    value = os.path.normpath(value)
+                settings[key.strip()] = value
     return settings
 
 

--- a/PythonPorjects/reality_mesh_gui.py
+++ b/PythonPorjects/reality_mesh_gui.py
@@ -27,7 +27,10 @@ def load_system_settings(path: str) -> dict:
                 if not line or line.startswith('#') or '=' not in line:
                     continue
                 key, value = line.split('=', 1)
-                settings[key.strip()] = value.strip()
+                value = value.strip()
+                if key.strip() == 'dataset_root':
+                    value = os.path.normpath(value)
+                settings[key.strip()] = value
     return settings
 
 

--- a/PythonPorjects/reality_mesh_monitor.py
+++ b/PythonPorjects/reality_mesh_monitor.py
@@ -22,7 +22,10 @@ def load_system_settings(path: str) -> dict:
                 continue
             if '=' in line:
                 key, value = line.split('=', 1)
-                settings[key.strip()] = value.strip()
+                value = value.strip()
+                if key.strip() == 'dataset_root':
+                    value = os.path.normpath(value)
+                settings[key.strip()] = value
     return settings
 
 


### PR DESCRIPTION
## Summary
- ensure dataset_root values read from settings files are normalized

## Testing
- `python -m py_compile PythonPorjects/STE_Toolkit.py PythonPorjects/reality_mesh_gui.py PythonPorjects/reality_mesh_monitor.py`

------
https://chatgpt.com/codex/tasks/task_e_688b7180394883229a58ba42ed85ef3b