### PR TITLE
Normalize selected paths

### DIFF
--- a/PythonPorjects/STE_Toolkit.py
+++ b/PythonPorjects/STE_Toolkit.py
@@ -116,6 +116,15 @@ def get_local_ip():
     except Exception:
         return "127.0.0.1"
 
+
+def clean_path(path: str) -> str:
+    """Return *path* normalized with UNC style backslashes."""
+    path = os.path.normpath(path.strip())
+    path = path.replace('/', '\\')
+    if path.startswith('\\') and not path.startswith('\\\\'):
+        path = '\\' + path
+    return path
+
 #==============================================================================
 # VBS4 INSTALL PATH FINDER
 #==============================================================================
@@ -1880,7 +1889,7 @@ class MainApp(tk.Tk):
             filetypes=[("Executable Files", "*.exe")]
         )
         if path and os.path.exists(path):
-            config['General'][config_key] = path
+            config['General'][config_key] = clean_path(path)
             with open(CONFIG_PATH, 'w') as f:
                 config.write(f)
             messagebox.showinfo("Success", f"{app_name} path set to:\n{path}")
@@ -2451,7 +2460,7 @@ class VBS4Panel(tk.Frame):
             filetypes=[("Executable Files", "*.exe")]
         )
         if path and os.path.exists(path):
-            config['General'][config_key] = path
+            config['General'][config_key] = clean_path(path)
             with open(CONFIG_PATH, 'w') as f:
                 config.write(f)
             messagebox.showinfo("Success", f"{app_name} path set to:\n{path}")
@@ -2516,7 +2525,7 @@ class VBS4Panel(tk.Frame):
                 parent=folder_window,
             )
             if path and os.path.exists(path):
-                norm = os.path.normpath(path)
+                norm = clean_path(path)
                 found = get_image_folders_recursively(norm)
                 folders.extend(found)
             else:
@@ -2524,7 +2533,7 @@ class VBS4Panel(tk.Frame):
                     title="Select DCIM or base imagery folder", parent=folder_window
                 )
                 if selected:
-                    norm = os.path.normpath(selected)
+                    norm = clean_path(selected)
                     found = get_image_folders_recursively(norm)
                     folders.extend(found)
 
@@ -2547,7 +2556,7 @@ class VBS4Panel(tk.Frame):
                 )
                 return
 
-            norm_folders = [os.path.normpath(f) for f in folders]
+            norm_folders = [clean_path(f) for f in folders]
             self.image_folder_paths = norm_folders
             self.image_folder_path = ";".join(norm_folders)
             messagebox.showinfo(
@@ -3089,7 +3098,7 @@ class BVIPanel(tk.Frame):
             filetypes=[("Executable Files", "*.exe")]
         )
         if path and os.path.exists(path):
-            config['General'][config_key] = path
+            config['General'][config_key] = clean_path(path)
             with open(CONFIG_PATH, 'w') as f:
                 config.write(f)
             messagebox.showinfo("Success", f"{app_name} path set to:\n{path}")


### PR DESCRIPTION
## Summary
- ensure `set_file_location` uses cleaned path values
- normalize forward/back slashes for imagery selections
- add `clean_path` helper

## Testing
- `python -m py_compile PythonPorjects/STE_Toolkit.py`
- `python -m py_compile PythonPorjects/post_process_utils.py`


------
https://chatgpt.com/codex/tasks/task_e_688b7830d1948322b6bb08efc23a49a2

## Summary by Sourcery

Introduce a unified path cleaning utility and apply it across file and imagery selections to ensure consistent UNC-style backslashes in stored configuration and image folder paths.

Enhancements:
- Add clean_path helper to normalize paths with os.path.normpath, convert forward slashes to backslashes, and enforce UNC-style leading backslashes
- Update set_file_location to use clean_path when writing executable paths to the config
- Replace os.path.normpath calls with clean_path in imagery folder selection routines and final image folder path list