### PR TITLE
Fix UNC path normalization in imagery folder search

### DIFF
--- a/PythonPorjects/STE_Toolkit.py
+++ b/PythonPorjects/STE_Toolkit.py
@@ -903,18 +903,21 @@ def get_image_folders_recursively(base_folder):
     ``os.walk`` preserves whatever path separators the caller provides. When a
     user enters a path with forward slashes on Windows this can result in mixed
     ``/`` and ``\`` in the returned folder names. Normalizing both the base
-    folder and discovered paths ensures consistent separators.
+    folder and discovered paths ensures consistent separators and proper UNC
+    handling.
     """
 
-    base_folder = os.path.normpath(base_folder)
+    base_folder = clean_path(base_folder)
     image_folders = []
+
     for root, dirs, files in os.walk(base_folder):
-        root = os.path.normpath(root)
+        root = clean_path(root)
         if any(
             file.lower().endswith((".jpg", ".jpeg", ".png", ".tif", ".tiff"))
             for file in files
         ):
             image_folders.append(root)
+
     return image_folders
 
 def create_app_button(parent, app_name, get_path_func, launch_func, set_path_func):
@@ -2525,16 +2528,14 @@ class VBS4Panel(tk.Frame):
                 parent=folder_window,
             )
             if path and os.path.exists(path):
-                norm = clean_path(path)
-                found = get_image_folders_recursively(norm)
+                found = get_image_folders_recursively(clean_path(path))
                 folders.extend(found)
             else:
                 selected = filedialog.askdirectory(
                     title="Select DCIM or base imagery folder", parent=folder_window
                 )
                 if selected:
-                    norm = clean_path(selected)
-                    found = get_image_folders_recursively(norm)
+                    found = get_image_folders_recursively(clean_path(selected))
                     folders.extend(found)
 
             # Update listbox


### PR DESCRIPTION
## Summary
- ensure image folder scanning normalizes paths
- normalize user-selected folders before scanning

## Testing
- `python -m py_compile PythonPorjects/STE_Toolkit.py`


------
https://chatgpt.com/codex/tasks/task_e_688b7bcc36c08322b607f00b0876d286

## Summary by Sourcery

Fix UNC path normalization in image folder scanning and streamline folder addition

Bug Fixes:
- Normalize base and discovered paths with clean_path in get_image_folders_recursively to properly handle UNC paths

Enhancements:
- Refactor add_folder to directly pass cleaned paths to get_image_folders_recursively instead of normalizing separately

Documentation:
- Update docstring to reference UNC path handling