### PR TITLE
Normalize project path for PhotoMesh Wizard

### DIFF
--- a/PythonPorjects/STE_Toolkit.py
+++ b/PythonPorjects/STE_Toolkit.py
@@ -2757,6 +2757,8 @@ class VBS4Panel(tk.Frame):
         if not project_path:
             messagebox.showwarning("Missing Folder", "Project output folder is required.", parent=self)
             return
+        # Normalize to UNC style backslashes for PhotoMesh
+        project_path = clean_path(project_path)
         update_fuser_shared_path(project_path)
         wizard_path = r"C:\Program Files\Skyline\PhotoMeshWizard\PhotoMeshWizard.exe"
 


### PR DESCRIPTION
## Summary
- normalize the selected project path when launching the PhotoMesh Wizard

## Testing
- `python -m py_compile PythonPorjects/RealityMeshStandalone.py PythonPorjects/STE_Toolkit.py PythonPorjects/photomesh/RealityMesh_tt/remap.py PythonPorjects/post_process_utils.py PythonPorjects/reality_mesh_gui.py PythonPorjects/reality_mesh_monitor.py 'PythonPorjects/steup/Gui tezt.py' PythonPorjects/steup/get_exe_version.py`

------
https://chatgpt.com/codex/tasks/task_e_688b81ab252883228abac6ef5413f109

## Summary by Sourcery

Enhancements:
- Normalize the selected project path to use UNC-style backslashes with clean_path before launching PhotoMesh Wizard.