### PR TITLE
Fix PyInstaller handling for Reality Mesh GUI

### DIFF
--- a/PythonPorjects/RealityMeshStandalone.py
+++ b/PythonPorjects/RealityMeshStandalone.py
@@ -9,13 +9,23 @@ python RealityMeshStandalone.py
 
 import os
 import sys
+import importlib
 
-# Ensure this script can locate the bundled GUI module regardless of where it's launched from
-BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+def _resource_base() -> str:
+    """Return the directory containing bundled resources."""
+    if getattr(sys, "frozen", False):
+        return getattr(sys, "_MEIPASS", os.path.dirname(sys.executable))
+    return os.path.dirname(os.path.abspath(__file__))
+
+# Ensure this script can locate ``reality_mesh_gui`` when run from a frozen
+# bundle or directly from source.
+BASE_DIR = _resource_base()
 if BASE_DIR not in sys.path:
     sys.path.insert(0, BASE_DIR)
 
-from reality_mesh_gui import main
+def main() -> None:
+    gui = importlib.import_module("reality_mesh_gui")
+    gui.main()
 
 if __name__ == "__main__":
     main()

--- a/PythonPorjects/reality_mesh_gui.py
+++ b/PythonPorjects/reality_mesh_gui.py
@@ -3,6 +3,7 @@ from tkinter import filedialog, messagebox, scrolledtext, ttk
 from PIL import Image, ImageTk
 import threading
 import os
+import sys
 import time
 import json
 import shutil
@@ -16,6 +17,13 @@ from STE_Toolkit import (
     distribute_terrain,
 )
 from post_process_utils import clean_project_settings
+
+# Base directory for bundled resources when packaged by PyInstaller
+BASE_DIR = getattr(sys, "_MEIPASS", os.path.dirname(os.path.abspath(__file__)))
+
+def resource_path(*parts: str) -> str:
+    """Return the absolute path to a resource bundled with the application."""
+    return os.path.join(BASE_DIR, *parts)
 
 
 def load_system_settings(path: str) -> dict:
@@ -302,8 +310,7 @@ class RealityMeshGUI(tk.Tk):
         self.logo_photo = None
 
         self.build_dir = tk.StringVar()
-        base_dir = os.path.dirname(os.path.abspath(__file__))
-        photomesh_dir = os.path.join(base_dir, 'photomesh')
+        photomesh_dir = resource_path('photomesh')
 
         # Paths to the system settings and PowerShell script are no longer
         # hard coded so the application can be distributed without assuming a


### PR DESCRIPTION
## Summary
- handle frozen PyInstaller environment when launching `RealityMeshStandalone`
- add helper for locating bundled data when frozen
- update GUI to use the helper so resources resolve correctly

## Testing
- `python -m py_compile PythonPorjects/RealityMeshStandalone.py PythonPorjects/reality_mesh_gui.py`

------
https://chatgpt.com/codex/tasks/task_e_688b9c97f0fc8322a891cf05fc764cc0