### PR TITLE
Fix PyInstaller handling for Reality Mesh GUI

### DIFF
--- a/PythonPorjects/RealityMeshStandalone.py
+++ b/PythonPorjects/RealityMeshStandalone.py
@@ -9,13 +9,35 @@ python RealityMeshStandalone.py
 
 import os
 import sys
+import importlib
+import logging
 
-# Ensure this script can locate the bundled GUI module regardless of where it's launched from
-BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+def _resource_base() -> str:
+    """Return the directory containing bundled resources."""
+    if getattr(sys, "frozen", False):
+        return getattr(sys, "_MEIPASS", os.path.dirname(sys.executable))
+    return os.path.dirname(os.path.abspath(__file__))
+
+# Ensure this script can locate ``reality_mesh_gui`` when run from a frozen
+# bundle or directly from source.
+BASE_DIR = _resource_base()
 if BASE_DIR not in sys.path:
     sys.path.insert(0, BASE_DIR)
 
-from reality_mesh_gui import main
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s - %(levelname)s - %(message)s'
+)
+logging.info("RealityMeshStandalone starting")
+
+def main() -> None:
+    logging.info("Importing reality_mesh_gui")
+    try:
+        gui = importlib.import_module("reality_mesh_gui")
+        gui.main()
+    except Exception:
+        logging.exception("Failed to start reality_mesh_gui")
+        raise
 
 if __name__ == "__main__":
     main()

--- a/PythonPorjects/STE_Toolkit.py
+++ b/PythonPorjects/STE_Toolkit.py
@@ -2961,23 +2961,35 @@ class VBS4Panel(tk.Frame):
         messagebox.showinfo("Terrain Tutorial", "One-Click Terrain Tutorial to be implemented.", parent=self)
 
     def open_reality_mesh_gui(self):
-        script_dir = os.path.dirname(os.path.abspath(__file__))
-        script_path = os.path.join(script_dir, 'RealityMeshStandalone.py')
-
-        # When running from a PyInstaller build, sys.executable points to the
-        # bundled executable rather than the Python interpreter. Launching the
-        # script with this path would simply reopen the current application.
+        """Launch the standalone Reality Mesh GUI."""
         if getattr(sys, 'frozen', False):
-            exe_path = os.path.join(os.path.dirname(sys.executable),
-                                   'RealityMeshStandalone.exe')
-            if os.path.exists(exe_path):
-                subprocess.Popen([exe_path])
-                return
-            python_exe = 'python'
+            base_dir = os.path.dirname(sys.executable)
         else:
-            python_exe = sys.executable if sys.executable else 'python'
+            base_dir = os.path.dirname(os.path.abspath(__file__))
 
-        subprocess.Popen([python_exe, script_path])
+        script_path = os.path.join(base_dir, 'RealityMeshStandalone.py')
+        log_path = os.path.join(base_dir, 'reality_mesh_launch.log')
+        logging.info("Launching RealityMeshStandalone: %s", script_path)
+
+        if not os.path.exists(script_path):
+            msg = f"Could not find RealityMeshStandalone.py at:\n{script_path}"
+            logging.error(msg)
+            messagebox.showerror("Error", msg, parent=self)
+            return
+
+        try:
+            with open(log_path, 'a', encoding='utf-8') as log_file:
+                log_file.write(f"=== Launch {datetime.now()} ===\n")
+                subprocess.Popen(
+                    [sys.executable, script_path],
+                    stdout=log_file,
+                    stderr=subprocess.STDOUT,
+                )
+        except Exception as e:
+            logging.exception("Failed to launch RealityMeshStandalone")
+            messagebox.showerror("Error", str(e), parent=self)
+            return
+        logging.info("RealityMeshStandalone started")
 
     def log_message(self, message):
          self.log_text.config(state="normal")

--- a/PythonPorjects/reality_mesh_gui.py
+++ b/PythonPorjects/reality_mesh_gui.py
@@ -3,10 +3,12 @@ from tkinter import filedialog, messagebox, scrolledtext, ttk
 from PIL import Image, ImageTk
 import threading
 import os
+import sys
 import time
 import json
 import shutil
 import subprocess
+import logging
 from datetime import datetime
 import re
 from collections import OrderedDict
@@ -16,6 +18,19 @@ from STE_Toolkit import (
     distribute_terrain,
 )
 from post_process_utils import clean_project_settings
+
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s - %(levelname)s - %(message)s'
+)
+log = logging.getLogger(__name__)
+
+# Base directory for bundled resources when packaged by PyInstaller
+BASE_DIR = getattr(sys, "_MEIPASS", os.path.dirname(os.path.abspath(__file__)))
+
+def resource_path(*parts: str) -> str:
+    """Return the absolute path to a resource bundled with the application."""
+    return os.path.join(BASE_DIR, *parts)
 
 
 def load_system_settings(path: str) -> dict:
@@ -302,8 +317,7 @@ class RealityMeshGUI(tk.Tk):
         self.logo_photo = None
 
         self.build_dir = tk.StringVar()
-        base_dir = os.path.dirname(os.path.abspath(__file__))
-        photomesh_dir = os.path.join(base_dir, 'photomesh')
+        photomesh_dir = resource_path('photomesh')
 
         # Paths to the system settings and PowerShell script are no longer
         # hard coded so the application can be distributed without assuming a
@@ -511,6 +525,7 @@ class RealityMeshGUI(tk.Tk):
 
 
 def main():
+    log.info("Reality Mesh GUI starting")
     app = RealityMeshGUI()
     app.mainloop()
 


### PR DESCRIPTION
## Summary
- handle frozen PyInstaller environment when launching `RealityMeshStandalone`
- add helper for locating bundled data when frozen
- update GUI to use the helper so resources resolve correctly
- launch standalone GUI using embedded Python interpreter
- add logging so failures launching RealityMeshStandalone are captured

## Testing
- `python -m py_compile PythonPorjects/RealityMeshStandalone.py PythonPorjects/reality_mesh_gui.py PythonPorjects/STE_Toolkit.py`


------
https://chatgpt.com/codex/tasks/task_e_688b9c97f0fc8322a891cf05fc764cc0

## Summary by Sourcery

Support launching RealityMeshStandalone in both source and PyInstaller-frozen environments by adding resource-location helpers, updating launch logic, and enhancing logging and error handling.

New Features:
- Add _resource_base and resource_path helpers to locate bundled resources in frozen or development modes.
- Introduce logging setup in RealityMeshStandalone and reality_mesh_gui to record startup and errors.

Bug Fixes:
- Handle PyInstaller’s frozen execuable correctly when launching RealityMeshStandalone from the GUI.

Enhancements:
- Write standalone GUI stdout and stderr to a log file and show error dialogs on launch failures.
- Use importlib to dynamically import and run the GUI module with exception logging.