### PR TITLE
Remove exe fallback for RealityMesh

### DIFF
--- a/PythonPorjects/STE_Toolkit.py
+++ b/PythonPorjects/STE_Toolkit.py
@@ -2961,43 +2961,18 @@ class VBS4Panel(tk.Frame):
         messagebox.showinfo("Terrain Tutorial", "One-Click Terrain Tutorial to be implemented.", parent=self)
 
     def open_reality_mesh_gui(self):
-        """Launch the standalone Reality Mesh GUI."""
-        if getattr(sys, 'frozen', False):
-            base_dir = os.path.dirname(sys.executable)
-        else:
-            base_dir = os.path.dirname(os.path.abspath(__file__))
+        """Launch the Reality Mesh GUI script from the current directory."""
+        base_dir = os.path.dirname(os.path.abspath(__file__))
+        py_path = os.path.join(base_dir, 'RealityMeshStandalone.py')
 
-        exe_path = os.path.join(base_dir, 'RealityMeshStandalone.exe')
-        script_path = os.path.join(base_dir, 'RealityMeshStandalone.py')
-        log_path = os.path.join(base_dir, 'reality_mesh_launch.log')
-
-        if os.path.exists(exe_path):
-            command = [exe_path]
-            logging.info("Launching RealityMeshStandalone executable: %s", exe_path)
-        elif os.path.exists(script_path):
-            command = [sys.executable, script_path]
-            logging.info("Launching RealityMeshStandalone script: %s", script_path)
-        else:
-            msg = (
-                "Could not find RealityMeshStandalone.exe or .py in:\n" + base_dir
-            )
-            logging.error(msg)
-            messagebox.showerror("Error", msg, parent=self)
+        if os.path.exists(py_path):
+            subprocess.Popen([sys.executable, py_path])
             return
 
-        try:
-            with open(log_path, 'a', encoding='utf-8') as log_file:
-                log_file.write(f"=== Launch {datetime.now()} ===\n")
-                subprocess.Popen(
-                    command,
-                    stdout=log_file,
-                    stderr=subprocess.STDOUT,
-                )
-        except Exception as e:
-            logging.exception("Failed to launch RealityMeshStandalone")
-            messagebox.showerror("Error", str(e), parent=self)
-            return
-        logging.info("RealityMeshStandalone started")
+        messagebox.showerror(
+            "Error",
+            f"Could not find RealityMeshStandalone at:\n{py_path}"
+        )
 
     def log_message(self, message):
          self.log_text.config(state="normal")

--- a/README.md
+++ b/README.md
@@ -25,10 +25,10 @@ Launch it from the repository root with:
 python PythonPorjects/RealityMeshStandalone.py
 ```
 
-When running a packaged release created with PyInstaller, a
-`RealityMeshStandalone.exe` is located next to the main toolkit
-executable. The "Open Standalone Post-Processor" button now looks for
-this executable and launches it when available.
+When running a packaged release created with PyInstaller, the
+`RealityMeshStandalone.py` script is bundled next to the main toolkit
+executable. The "Open Standalone Post-Processor" button launches this
+script directly using the embedded Python interpreter.
 
 Avoid hard‑coded absolute paths so the tool can be executed from any checkout location.
 The required `RealityMeshProcess.ps1` script and `RealityMeshSystemSettings.txt` file


### PR DESCRIPTION
## Summary
- only launch `RealityMeshStandalone.py` from the current directory
- update readme instructions since no standalone exe is shipped

## Testing
- `find PythonPorjects -name '*.py' -print0 | xargs -0 python3 -m py_compile`


------
https://chatgpt.com/codex/tasks/task_e_688bb26bc9b48322b43a28e43ea2ca85

## Summary by Sourcery

Remove the fallback to RealityMeshStandalone.exe and simplify the launch logic to always run the Python script from the current directory, and update documentation to match this behavior.

Enhancements:
- Simplify open_reality_mesh_gui to only launch RealityMeshStandalone.py and remove executable and log file handling.

Documentation:
- Update README to describe launching the Python script with the embedded interpreter instead of an executable.