### PR TITLE
Add launch error logging

### DIFF
--- a/PythonPorjects/RealityMeshStandalone.py
+++ b/PythonPorjects/RealityMeshStandalone.py
@@ -11,6 +11,7 @@ import os
 import sys
 import importlib
 import logging
+import traceback
 
 def _resource_base() -> str:
     """Return the directory containing bundled resources."""
@@ -26,9 +27,13 @@ if BASE_DIR not in sys.path:
 
 logging.basicConfig(
     level=logging.INFO,
+    filename='reality_mesh.log',
+    filemode='a',
     format='%(asctime)s - %(levelname)s - %(message)s'
 )
 logging.info("RealityMeshStandalone starting")
+
+print("Starting GUI...")
 
 def main() -> None:
     logging.info("Importing reality_mesh_gui")
@@ -37,6 +42,8 @@ def main() -> None:
         gui.main()
     except Exception:
         logging.exception("Failed to start reality_mesh_gui")
+        with open("gui_error.log", "w") as f:
+            f.write(traceback.format_exc())
         raise
 
 if __name__ == "__main__":

--- a/PythonPorjects/STE_Toolkit.py
+++ b/PythonPorjects/STE_Toolkit.py
@@ -2966,9 +2966,22 @@ class VBS4Panel(tk.Frame):
         py_path = os.path.join(base_dir, 'RealityMeshStandalone.py')
 
         if os.path.exists(py_path):
-            subprocess.Popen([sys.executable, py_path])
-            return
+            self.log_message(f"Launching RealityMeshStandalone: {py_path}")
+            logging.info("Launching RealityMeshStandalone: %s", py_path)
+            try:
+                subprocess.Popen(
+                    [sys.executable, py_path],
+                    creationflags=subprocess.CREATE_NEW_CONSOLE
+                )
+                return
+            except Exception as e:  # pragma: no cover - GUI path
+                self.log_message(f"Failed to launch RealityMeshStandalone: {e}")
+                logging.exception("Failed to launch RealityMeshStandalone")
+                messagebox.showerror("Error", str(e), parent=self)
+                return
 
+        self.log_message(f"RealityMeshStandalone not found at: {py_path}")
+        logging.error("RealityMeshStandalone not found at %s", py_path)
         messagebox.showerror(
             "Error",
             f"Could not find RealityMeshStandalone at:\n{py_path}"


### PR DESCRIPTION
## Summary
- record Reality Mesh launcher status to `reality_mesh.log`
- log failures when launching the GUI from the toolkit

## Testing
- `python -m py_compile PythonPorjects/RealityMeshStandalone.py PythonPorjects/STE_Toolkit.py`


------
https://chatgpt.com/codex/tasks/task_e_688bbc516d208322a79a0e263216b94d

## Summary by Sourcery

Add error logging and status reporting when launching RealityMeshStandalone from the STE Toolkit and enhance logging in the standalone script

Enhancements:
- Log RealityMeshStandalone launch attempts, successes, and failures in STE_Toolkit
- Configure RealityMeshStandalone to append startup logs to reality_mesh.log with timestamps
- Capture GUI initialization exceptions to gui_error.log and display error dialogs on failure