### PR TITLE
Fix RealityMesh GUI launch path

### DIFF
--- a/PythonPorjects/RealityMeshStandalone.py
+++ b/PythonPorjects/RealityMeshStandalone.py
@@ -11,6 +11,7 @@ import os
 import sys
 import importlib
 import logging
+import traceback
 
 def _resource_base() -> str:
     """Return the directory containing bundled resources."""
@@ -26,9 +27,13 @@ if BASE_DIR not in sys.path:
 
 logging.basicConfig(
     level=logging.INFO,
+    filename='reality_mesh.log',
+    filemode='a',
     format='%(asctime)s - %(levelname)s - %(message)s'
 )
 logging.info("RealityMeshStandalone starting")
+
+print("Starting GUI...")
 
 def main() -> None:
     logging.info("Importing reality_mesh_gui")
@@ -37,6 +42,8 @@ def main() -> None:
         gui.main()
     except Exception:
         logging.exception("Failed to start reality_mesh_gui")
+        with open("gui_error.log", "w") as f:
+            f.write(traceback.format_exc())
         raise
 
 if __name__ == "__main__":

--- a/PythonPorjects/STE_Toolkit.py
+++ b/PythonPorjects/STE_Toolkit.py
@@ -2963,12 +2963,25 @@ class VBS4Panel(tk.Frame):
     def open_reality_mesh_gui(self):
         """Launch the Reality Mesh GUI script from the current directory."""
         base_dir = os.path.dirname(os.path.abspath(__file__))
-        py_path = os.path.join(base_dir, 'RealityMeshStandalone.py')
+        py_path = os.path.join(base_dir, '_internal', 'RealityMeshStandalone.py')
 
         if os.path.exists(py_path):
-            subprocess.Popen([sys.executable, py_path])
-            return
+            self.log_message(f"Launching RealityMeshStandalone: {py_path}")
+            logging.info("Launching RealityMeshStandalone: %s", py_path)
+            try:
+                subprocess.Popen(
+                    [sys.executable, py_path],
+                    creationflags=subprocess.CREATE_NEW_CONSOLE
+                )
+                return
+            except Exception as e:  # pragma: no cover - GUI path
+                self.log_message(f"Failed to launch RealityMeshStandalone: {e}")
+                logging.exception("Failed to launch RealityMeshStandalone")
+                messagebox.showerror("Error", str(e), parent=self)
+                return
 
+        self.log_message(f"RealityMeshStandalone not found at: {py_path}")
+        logging.error("RealityMeshStandalone not found at %s", py_path)
         messagebox.showerror(
             "Error",
             f"Could not find RealityMeshStandalone at:\n{py_path}"


### PR DESCRIPTION
## Summary
- adjust STE_Toolkit to locate RealityMeshStandalone inside `_internal`

## Testing
- `python -m py_compile PythonPorjects/RealityMeshStandalone.py PythonPorjects/STE_Toolkit.py`


------
https://chatgpt.com/codex/tasks/task_e_688bbc516d208322a79a0e263216b94d

## Summary by Sourcery

Improve the launch path and error handling for RealityMeshStandalone by relocating the script to an internal folder, adding logging and console settings in STE_Toolkit, and enhancing logging behavior in RealityMeshStandalone.

New Features:
- Spawn RealityMeshStandalone in a new console window

Enhancements:
- Adjust STE_Toolkit to locate RealityMeshStandalone inside the _internal directory
- Add logging of launch attempts and failures in STE_Toolkit with messagebox error dialogs
- Improve RealityMeshStandalone logging by outputting to reality_mesh.log and writing tracebacks to gui_error.log
- Print a startup message in RealityMeshStandalone