### PR TITLE
Set PhotoMesh defaults

### DIFF
--- a/PythonPorjects/STE_Toolkit.py
+++ b/PythonPorjects/STE_Toolkit.py
@@ -458,6 +458,8 @@ def write_project_settings(settings_path: str, data: dict, data_folder: str) -> 
     """
 
     defaults = OrderedDict([
+        ("export_format", "OBJ"),
+        ("center_pivot_to_project", "true"),
         ("orthocam_Resolution", "0.05"),
         ("orthocam_Render_Lowest", "1"),
         ("tin_to_dem_Resolution", "0.5"),
@@ -2783,7 +2785,11 @@ class VBS4Panel(tk.Frame):
                 return
 
         folders_cmd = " ".join([f'--folder "{folder}"' for folder in self.image_folder_paths])
-        cmd = f'"{wizard_path}" --projectName "{project_name}" --projectPath "{project_path}" {folders_cmd}'
+        default_opts = "--exportFormat OBJ --centerPivotToProject"
+        cmd = (
+            f'"{wizard_path}" --projectName "{project_name}" '
+            f'--projectPath "{project_path}" {default_opts} {folders_cmd}'
+        )
 
         self.log_message(f"Creating mesh for project: {project_name}")
         self.log_message(f"Running command:\n{cmd}")

--- a/PythonPorjects/photomesh/RealityMeshSystemSettings.txt
+++ b/PythonPorjects/photomesh/RealityMeshSystemSettings.txt
@@ -9,3 +9,5 @@ override_Path_DevSuite=P
 terratools_ssh_path=C:\Program Files\Bohemia Interactive Simulations\TerraTools\bin\terratoolssh.exe
 terratools_home_path=C:\Program Files\Bohemia Interactive Simulations\TerraTools
 dataset_root=C:\BiSim OneClick\Datasets
+export_format=OBJ
+center_pivot_to_project=true

--- a/PythonPorjects/reality_mesh_gui.py
+++ b/PythonPorjects/reality_mesh_gui.py
@@ -171,6 +171,8 @@ def write_project_settings(settings_path: str, data: dict, data_folder: str):
     """
 
     defaults = OrderedDict([
+        ("export_format", "OBJ"),
+        ("center_pivot_to_project", "true"),
         ("orthocam_Resolution", "0.05"),
         ("orthocam_Render_Lowest", "1"),
         ("tin_to_dem_Resolution", "0.5"),

--- a/PythonPorjects/reality_mesh_monitor.py
+++ b/PythonPorjects/reality_mesh_monitor.py
@@ -100,6 +100,8 @@ def write_project_settings(settings_path: str, data: dict, data_folder: str) -> 
     """
 
     defaults = OrderedDict([
+        ("export_format", "OBJ"),
+        ("center_pivot_to_project", "true"),
         ("orthocam_Resolution", "0.05"),
         ("orthocam_Render_Lowest", "1"),
         ("tin_to_dem_Resolution", "0.5"),

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ This repository contains automation scripts for processing PhotoMesh builds and 
 9. **Copy Output to All VBS4 Install Locations** – Generated terrain is replicated to all configured VBS4 installations as defined in `distribution_paths.json`.
 10. **Close PhotoMesh Fuser Processes** – All running `Fuser.exe` instances are terminated.
 
+The toolkit now sets PhotoMesh to export **OBJ** files and enable the **Center Pivot to Project** option by default when launching the PhotoMesh Wizard.
+
 The `distribution_paths.json` file lists remote VBS4 install paths. Update it with UNC paths to ensure terrain packages are synchronized across machines.
 
 ## Running the Standalone Post‑Processor

--- a/RealityMeshSystemSettings.txt
+++ b/RealityMeshSystemSettings.txt
@@ -10,3 +10,5 @@ terratools_ssh_path=C:\Program Files\Bohemia Interactive Simulations\TerraTools\
 terratools_home_path=C:\Program Files\Bohemia Interactive Simulations\TerraTools
 
 dataset_root=C:\BiSim OneClick\Datasets
+export_format=OBJ
+center_pivot_to_project=true


### PR DESCRIPTION
## Summary
- default to OBJ output with center-pivot option
- mention new default behavior in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688bd7ac69e083229c875fba2d81ea10

## Summary by Sourcery

Set default PhotoMesh output format to OBJ and enable center-pivot-to-project in project settings and wizard invocation, and update documentation to reflect these defaults.

Enhancements:
- Initialize export_format as OBJ and center_pivot_to_project as true in project settings writers
- Include --exportFormat OBJ and --centerPivotToProject options in the PhotoMesh wizard command

Documentation:
- Update README to mention default OBJ export format and center-pivot-to-project behavior