### PR TITLE
Implement PhotoMesh one-click launch

### DIFF
--- a/PythonPorjects/STE_Toolkit.py
+++ b/PythonPorjects/STE_Toolkit.py
@@ -19,7 +19,7 @@ import socket
 import threading
 import shlex
 from post_process_utils import clean_project_settings
-from launch_photomesh_preset import launch_photomesh_with_preset
+from launch_photomesh_preset import run_photomesh_one_click_conversion
 from collections import OrderedDict
 import time
 import glob
@@ -2795,7 +2795,7 @@ class VBS4Panel(tk.Frame):
         self.log_message(f"Creating mesh for project: {project_name}")
 
         try:
-            launch_photomesh_with_preset(project_name, project_path, self.image_folder_paths)
+            run_photomesh_one_click_conversion(project_name, project_path, self.image_folder_paths)
             self.log_message("PhotoMesh Wizard launched successfully.")
             messagebox.showinfo(
                 "PhotoMesh Wizard Launched",


### PR DESCRIPTION
## Summary
- import `run_photomesh_one_click_conversion` instead of `launch_photomesh_with_preset`
- add `run_photomesh_one_click_conversion` for preset/config setup and launching PhotoMesh
- log preset and config creation and launch status
- use new function when creating a mesh

## Testing
- `python3 -m py_compile PythonPorjects/launch_photomesh_preset.py PythonPorjects/STE_Toolkit.py`

------
https://chatgpt.com/codex/tasks/task_e_688cf0ed27a0832298a0fe790ae5799e

## Summary by Sourcery

Implement a one-click PhotoMesh conversion workflow by introducing run_photomesh_one_click_conversion, enhancing logging around preset/config setup and launch, and updating mesh creation to use the new function

New Features:
- Add run_photomesh_one_click_conversion to set up presets and configs and launch PhotoMesh Wizard with a single call

Enhancements:
- Log preset existence, creation, config writing, and launch steps for better traceability
- Launch PhotoMesh Wizard minimized on Windows by configuring startupinfo
- Replace launch_photomesh_with_preset with run_photomesh_one_click_conversion in create_mesh