### PR TITLE
Set default PhotoMesh preset

### DIFF
--- a/PythonPorjects/STE_Toolkit.py
+++ b/PythonPorjects/STE_Toolkit.py
@@ -19,7 +19,10 @@ import socket
 import threading
 import shlex
 from post_process_utils import clean_project_settings
-from launch_photomesh_preset import launch_photomesh_with_preset
+from launch_photomesh_preset import (
+    launch_photomesh_with_preset,
+    set_photomesh_preset,
+)
 from collections import OrderedDict
 import time
 import glob
@@ -2089,6 +2092,7 @@ class VBS4Panel(tk.Frame):
         self.create_vbs4_folder_button()
         self.tooltip = Tooltip(self)
         enable_obj_in_photomesh_config()
+        set_photomesh_preset()
 
         tk.Label(
             self,
@@ -2795,6 +2799,7 @@ class VBS4Panel(tk.Frame):
         self.log_message(f"Creating mesh for project: {project_name}")
 
         try:
+            set_photomesh_preset()
             launch_photomesh_with_preset(project_name, project_path, self.image_folder_paths)
             self.log_message("PhotoMesh Wizard launched successfully.")
             messagebox.showinfo(


### PR DESCRIPTION
## Summary
- set CPP&OBJ preset file in `%APPDATA%` if missing
- update wizard `config.json` to select the preset and enable autobuild
- expose `set_photomesh_preset` helper and use it in `STE_Toolkit.py`

## Testing
- `python -m py_compile PythonPorjects/launch_photomesh_preset.py PythonPorjects/STE_Toolkit.py`

------
https://chatgpt.com/codex/tasks/task_e_688cfd94b7f48322925b46ddd84c746b