### PR TITLE
Fix redundant PhotoMesh preset setup

### DIFF
--- a/PythonPorjects/STE_Toolkit.py
+++ b/PythonPorjects/STE_Toolkit.py
@@ -2179,9 +2179,7 @@ class VBS4Panel(tk.Frame):
         self.tooltip = Tooltip(self)
         enable_obj_in_photomesh_config()
         write_cpp_obj_preset()
-        set_active_wizard_preset()   
-        set_photomesh_preset()
-
+        set_active_wizard_preset()
 
         tk.Label(
             self,
@@ -2890,7 +2888,6 @@ class VBS4Panel(tk.Frame):
         self.log_message(f"Creating mesh for project: {project_name}")
 
         try:
-            set_photomesh_preset()
             launch_photomesh_with_preset(project_name, project_path, self.image_folder_paths)
             self.log_message("PhotoMesh Wizard launched successfully.")
             messagebox.showinfo(


### PR DESCRIPTION
## Summary
- call `set_photomesh_preset` only from the PhotoMesh launcher
- remove extra blank line

## Testing
- `python -m py_compile PythonPorjects/**/*.py`

------
https://chatgpt.com/codex/tasks/task_e_688d0da2569483228071607f13d21ebc

## Summary by Sourcery

Remove redundant PhotoMesh preset invocations to ensure the preset is only applied when launching PhotoMesh and clean up extra blank lines.

Bug Fixes:
- Eliminate duplicate calls to set_photomesh_preset and restrict the preset setup to the PhotoMesh launcher path.

Enhancements:
- Remove an unnecessary blank line in the code.