### PR TITLE
Normalize UNC paths and quote file operations

### DIFF
--- a/PythonPorjects/photomesh/RealityMeshProcess.ps1
+++ b/PythonPorjects/photomesh/RealityMeshProcess.ps1
@@ -2,10 +2,48 @@
 $project_settings_File = $args[0]
 $fully_automate = $args[1]
 
+function Normalize-UNCPath {
+    param([Parameter(Mandatory)][string]$Path)
+    # Convert // to \ and collapse triples, normalize slashes
+    $p = $Path -replace '/', '\'
+    $p = $p -replace '^[\]+', '\'  # keep single leading backslash for now
+    if ($p.StartsWith('\') -and -not $p.StartsWith('\\')) {
+        $p = "\" + $p  # now \\...
+    }
+    # Ensure exactly two leading backslashes for UNC
+    $p = $p -replace '^[\]{3,}', '\\'
+    if ($p.StartsWith('\') -and -not $p.StartsWith('\\')) { $p = "\" + $p }
+    if (-not $p.StartsWith('\\')) { $p = $p -replace '^[\]+', '' } # local paths stay local
+    return $p
+}
+
+function Sanitize-Name {
+    param([Parameter(Mandatory)][string]$Name)
+    # Remove invalid filename chars: \ / : * ? " < > | and trailing dots/spaces
+    $n = $Name -replace '[\/:*?"<>|]', '_'
+    $n = $n.Trim().TrimEnd('.')
+    return $n
+}
+
+function Ensure-Directory {
+    param([Parameter(Mandatory)][string]$Dir)
+    if (-not (Test-Path -LiteralPath $Dir)) {
+        New-Item -ItemType Directory -Path $Dir | Out-Null
+    }
+}
+
+function SafeJoin {
+    param(
+        [Parameter(Mandatory)][string]$Base,
+        [Parameter(Mandatory)][string]$Child
+    )
+    return (Join-Path -Path $Base -ChildPath $Child)
+}
+
 # Base shared drive accessible by both the calling and remote machines
-$sharedRoot = "\\\SharedMeshDrive\RealityMesh"
-$inputRoot = Join-Path $sharedRoot 'Input'
-$outputRoot = Join-Path $sharedRoot 'Output'
+$sharedRoot = Normalize-UNCPath '\SharedMeshDrive\RealityMesh'
+$inputRoot = Normalize-UNCPath (SafeJoin $sharedRoot 'Input')
+$outputRoot = Normalize-UNCPath (SafeJoin $sharedRoot 'Output')
 
 if ([string]::IsNullOrEmpty($project_settings_File))
 {
@@ -14,21 +52,21 @@ if ([string]::IsNullOrEmpty($project_settings_File))
 
 if ([string]::IsNullOrEmpty($fully_automate))
 {
-	$fully_automate = 0
+        $fully_automate = 0
 }
 
-$project_settings_File = $project_settings_File.Trim("""")
+$project_settings_File = Normalize-UNCPath ($project_settings_File.Trim('"'))
 
 #Settings Parsing
 $system_settings = "$PSScriptRoot/RealityMeshSystemSettings.txt"
 
-if (!(Test-Path $project_settings_File)) {	
+if (!(Test-Path -LiteralPath $project_settings_File)) {
 	Write-Output "project settings file does not exist"
 	Read-Host -Prompt "Press Enter to exit"
 	Return
 }
 
-if (!(Test-Path $system_settings))
+if (!(Test-Path -LiteralPath $system_settings))
 {
 	Write-Output "System settings file does not exist"
 	Read-Host -Prompt "Press Enter to exit"
@@ -52,32 +90,45 @@ if (!(Test-Path $RealityMeshTTPath)) {
 }
 
 #Project settings
-$project_name = (Get-Content "$project_settings_File" | Where-Object { $_ -match "^project_name=" }) -replace "project_name=", ""
-$source_Directory_temp = (Get-Content "$project_settings_File" | Where-Object { $_ -match "^source_Directory=" }) -replace "source_Directory=", ""
-$source_Directory = $source_Directory_temp.Replace("\", "\\")
-$sel_Area_Size = (Get-Content "$project_settings_File" | Where-Object { $_ -match "^sel_Area_Size=" }) -replace "sel_Area_Size=", ""
-$offset_coordsys = (Get-Content "$project_settings_File" | Where-Object { $_ -match "^offset_coordsys=" }) -replace "offset_coordsys=", ""
-$offset_hdatum = (Get-Content "$project_settings_File" | Where-Object { $_ -match "^offset_hdatum=" }) -replace "offset_hdatum=", ""
-$offset_vdatum = (Get-Content "$project_settings_File" | Where-Object { $_ -match "^offset_vdatum=" }) -replace "offset_vdatum=", ""
-$offset_x = (Get-Content "$project_settings_File" | Where-Object { $_ -match "^offset_x=" }) -replace "offset_x=", ""
-$offset_y = (Get-Content "$project_settings_File" | Where-Object { $_ -match "^offset_y=" }) -replace "offset_y=", ""
-$offset_z = (Get-Content "$project_settings_File" | Where-Object { $_ -match "^offset_z=" }) -replace "offset_z=", ""
-$orthocam_Resolution = (Get-Content "$project_settings_File" | Where-Object { $_ -match "^orthocam_Resolution=" }) -replace "orthocam_Resolution=", ""
-$orthocam_Render_Lowest = (Get-Content "$project_settings_File" | Where-Object { $_ -match "^orthocam_Render_Lowest=" }) -replace "orthocam_Render_Lowest=", ""
-$tin_to_dem_Resolution = (Get-Content "$project_settings_File" | Where-Object { $_ -match "^tin_to_dem_Resolution=" }) -replace "tin_to_dem_Resolution=", ""
-$tile_scheme = (Get-Content "$project_settings_File" | Where-Object { $_ -match "^tile_scheme=" }) -replace "tile_scheme=", ""
-$collision = (Get-Content "$project_settings_File" | Where-Object { $_ -match "^collision=" }) -replace "collision=", ""
-$visualLODs = (Get-Content "$project_settings_File" | Where-Object { $_ -match "^visualLODs=" }) -replace "visualLODs=", ""
-$project_vdatum = (Get-Content "$project_settings_File" | Where-Object { $_ -match "^project_vdatum=" }) -replace "project_vdatum=", ""
-$offset_models = (Get-Content "$project_settings_File" | Where-Object { $_ -match "^offset_models=" }) -replace "offset_models=", ""
-$csf_options = (Get-Content "$project_settings_File" | Where-Object { $_ -match "^csf_options=" }) -replace "csf_options=", ""
-$faceThresh = (Get-Content "$project_settings_File" | Where-Object { $_ -match "^faceThresh=" }) -replace "faceThresh=", ""
-$lodThresh = (Get-Content "$project_settings_File" | Where-Object { $_ -match "^lodThresh=" }) -replace "lodThresh=", ""
-$tileSize = (Get-Content "$project_settings_File" | Where-Object { $_ -match "^tileSize=" }) -replace "tileSize=", ""
-$srfResolution = (Get-Content "$project_settings_File" | Where-Object { $_ -match "^srfResolution=" }) -replace "srfResolution=", ""
+$project_name = Sanitize-Name ((Get-Content -LiteralPath $project_settings_File | Where-Object { $_ -match "^project_name=" }) -replace "project_name=", "")
+$source_Directory_temp = (Get-Content -LiteralPath $project_settings_File | Where-Object { $_ -match "^source_Directory=" }) -replace "source_Directory=", ""
+$source_Directory = Normalize-UNCPath $source_Directory_temp
+
+# Attempt to derive a better project name from Output-CenterPivotOrigin.json
+$ocpo = Get-ChildItem -Path $source_Directory -Filter "Output-CenterPivotOrigin.json" -Recurse -ErrorAction SilentlyContinue | Select-Object -First 1
+if ($ocpo) {
+    $projectRoot = Split-Path $ocpo.DirectoryName -Parent
+    if ((Split-Path $ocpo.DirectoryName -Leaf) -like "Build_*") {
+        $projectRoot = Split-Path $projectRoot -Parent
+    }
+    $derivedName = Split-Path $projectRoot -Leaf
+    if ($derivedName) {
+        $project_name = Sanitize-Name $derivedName
+    }
+}
+$sel_Area_Size = (Get-Content -LiteralPath $project_settings_File | Where-Object { $_ -match "^sel_Area_Size=" }) -replace "sel_Area_Size=", ""
+$offset_coordsys = (Get-Content -LiteralPath $project_settings_File | Where-Object { $_ -match "^offset_coordsys=" }) -replace "offset_coordsys=", ""
+$offset_hdatum = (Get-Content -LiteralPath $project_settings_File | Where-Object { $_ -match "^offset_hdatum=" }) -replace "offset_hdatum=", ""
+$offset_vdatum = (Get-Content -LiteralPath $project_settings_File | Where-Object { $_ -match "^offset_vdatum=" }) -replace "offset_vdatum=", ""
+$offset_x = (Get-Content -LiteralPath $project_settings_File | Where-Object { $_ -match "^offset_x=" }) -replace "offset_x=", ""
+$offset_y = (Get-Content -LiteralPath $project_settings_File | Where-Object { $_ -match "^offset_y=" }) -replace "offset_y=", ""
+$offset_z = (Get-Content -LiteralPath $project_settings_File | Where-Object { $_ -match "^offset_z=" }) -replace "offset_z=", ""
+$orthocam_Resolution = (Get-Content -LiteralPath $project_settings_File | Where-Object { $_ -match "^orthocam_Resolution=" }) -replace "orthocam_Resolution=", ""
+$orthocam_Render_Lowest = (Get-Content -LiteralPath $project_settings_File | Where-Object { $_ -match "^orthocam_Render_Lowest=" }) -replace "orthocam_Render_Lowest=", ""
+$tin_to_dem_Resolution = (Get-Content -LiteralPath $project_settings_File | Where-Object { $_ -match "^tin_to_dem_Resolution=" }) -replace "tin_to_dem_Resolution=", ""
+$tile_scheme = (Get-Content -LiteralPath $project_settings_File | Where-Object { $_ -match "^tile_scheme=" }) -replace "tile_scheme=", ""
+$collision = (Get-Content -LiteralPath $project_settings_File | Where-Object { $_ -match "^collision=" }) -replace "collision=", ""
+$visualLODs = (Get-Content -LiteralPath $project_settings_File | Where-Object { $_ -match "^visualLODs=" }) -replace "visualLODs=", ""
+$project_vdatum = (Get-Content -LiteralPath $project_settings_File | Where-Object { $_ -match "^project_vdatum=" }) -replace "project_vdatum=", ""
+$offset_models = (Get-Content -LiteralPath $project_settings_File | Where-Object { $_ -match "^offset_models=" }) -replace "offset_models=", ""
+$csf_options = (Get-Content -LiteralPath $project_settings_File | Where-Object { $_ -match "^csf_options=" }) -replace "csf_options=", ""
+$faceThresh = (Get-Content -LiteralPath $project_settings_File | Where-Object { $_ -match "^faceThresh=" }) -replace "faceThresh=", ""
+$lodThresh = (Get-Content -LiteralPath $project_settings_File | Where-Object { $_ -match "^lodThresh=" }) -replace "lodThresh=", ""
+$tileSize = (Get-Content -LiteralPath $project_settings_File | Where-Object { $_ -match "^tileSize=" }) -replace "tileSize=", ""
+$srfResolution = (Get-Content -LiteralPath $project_settings_File | Where-Object { $_ -match "^srfResolution=" }) -replace "srfResolution=", ""
 
 #System settings
-$blender_path = (Get-Content "$system_settings" | Where-Object { $_ -match "^blender_path=" }) -replace "blender_path=", ""
+$blender_path = (Get-Content -LiteralPath $system_settings | Where-Object { $_ -match "^blender_path=" }) -replace "blender_path=", ""
 $default_blender = "C:\\Program Files\\Blender Foundation\\Blender 4.5\\blender.exe"
 if (!(Test-Path $blender_path)) {
         if (Test-Path $default_blender) {
@@ -100,20 +151,20 @@ if (!(Test-Path $blender_path)) {
                 }
         }
 }
-$blender_threads = (Get-Content "$system_settings" | Where-Object { $_ -match "^blender_threads=" }) -replace "blender_threads=", ""
-$override_Installation_VBS4 = (Get-Content "$system_settings" | Where-Object { $_ -match "^override_Installation_VBS4=" }) -replace "override_Installation_VBS4=", ""
-$override_Path_VBS4 = (Get-Content "$system_settings" | Where-Object { $_ -match "^override_Path_VBS4=" }) -replace "override_Path_VBS4=", ""
-if (($override_Installation_VBS4 -eq 1) -and !(Test-Path $override_Path_VBS4)) {	
+$blender_threads = (Get-Content -LiteralPath $system_settings | Where-Object { $_ -match "^blender_threads=" }) -replace "blender_threads=", ""
+$override_Installation_VBS4 = (Get-Content -LiteralPath $system_settings | Where-Object { $_ -match "^override_Installation_VBS4=" }) -replace "override_Installation_VBS4=", ""
+$override_Path_VBS4 = (Get-Content -LiteralPath $system_settings | Where-Object { $_ -match "^override_Path_VBS4=" }) -replace "override_Path_VBS4=", ""
+if (($override_Installation_VBS4 -eq 1) -and !(Test-Path -LiteralPath $override_Path_VBS4)) {	
 	Write-Output "VBS4 path invalid"
 	Read-Host -Prompt "Press Enter to exit"
 	Return
 }
-$vbs4_version = (Get-Content "$system_settings" | Where-Object { $_ -match "^vbs4_version=" }) -replace "vbs4_version=", ""
-$override_Installation_DevSuite = (Get-Content "$system_settings" | Where-Object { $_ -match "^override_Installation_DevSuite=" }) -replace "override_Installation_DevSuite=", ""
-$override_Path_DevSuite = (Get-Content "$system_settings" | Where-Object { $_ -match "^override_Path_DevSuite=" }) -replace "override_Path_DevSuite=", ""
-$terratools_home_path = (Get-Content "$system_settings" | Where-Object { $_ -match "^terratools_home_path=" }) -replace "terratools_home_path=", ""
-$terratools_ssh_path = (Get-Content "$system_settings" | Where-Object { $_ -match "^terratools_ssh_path=" }) -replace "terratools_ssh_path=", ""
-if (!(Test-Path $terratools_ssh_path)) {	
+$vbs4_version = (Get-Content -LiteralPath $system_settings | Where-Object { $_ -match "^vbs4_version=" }) -replace "vbs4_version=", ""
+$override_Installation_DevSuite = (Get-Content -LiteralPath $system_settings | Where-Object { $_ -match "^override_Installation_DevSuite=" }) -replace "override_Installation_DevSuite=", ""
+$override_Path_DevSuite = (Get-Content -LiteralPath $system_settings | Where-Object { $_ -match "^override_Path_DevSuite=" }) -replace "override_Path_DevSuite=", ""
+$terratools_home_path = (Get-Content -LiteralPath $system_settings | Where-Object { $_ -match "^terratools_home_path=" }) -replace "terratools_home_path=", ""
+$terratools_ssh_path = (Get-Content -LiteralPath $system_settings | Where-Object { $_ -match "^terratools_ssh_path=" }) -replace "terratools_ssh_path=", ""
+if (!(Test-Path -LiteralPath $terratools_ssh_path)) {	
 	Write-Output "Terratools Path invalid"
 	Read-Host -Prompt "Press Enter to exit"
 	Return
@@ -139,7 +190,7 @@ if ($AREYOUSURE -eq 'y') {
 		{
 			$newName = Read-Host -Prompt "$project_name already exists in projects folder.  Do you want to rename the project(a)?  Or cancel the process(b)?  (a/b)? "
 			if ($newName -eq 'a') {
-				$project_name = Read-Host -Prompt "Enter new name for project: "
+                                $project_name = Sanitize-Name (Read-Host -Prompt "Enter new name for project: ")
 			}
 			else {
 				Read-Host -Prompt "Process cancelled.  Press Enter to exit"
@@ -168,74 +219,78 @@ if ($AREYOUSURE -eq 'y') {
 		$delete = "y"
 	}
 	
-	if ($delete -eq 'y') {
-		#Command to clean out &override_Path_DevSuite%):\$project_name and $override_Path_DevSuite:\vbs2\customer\structures\%Name% on each run
-		$deletePath = "${override_Path_DevSuite}:\temp\RealityMesh\$project_name\"
-		if (Test-Path $deletePath) {
-			Write-Output "Deleting $deletePath"
-			Remove-Item $deletePath -Force -Recurse
-		}
-		
-		$deletePath2 = "${override_Path_DevSuite}:\vbs2\customer\structures\$project_name\"
-		if (Test-Path $deletePath2) {
-			Write-Output "Deleting $deletePath2"
-			Remove-Item $deletePath2 -Force -Recurse
-		}
-		
-		Write-Output "Cleaned files before creating new ones"
-	}	
+        if ($delete -eq 'y') {
+                #Command to clean out &override_Path_DevSuite%):\$project_name and $override_Path_DevSuite:\vbs2\customer\structures\%Name% on each run
+                $deletePath = "${override_Path_DevSuite}:\temp\RealityMesh\$project_name\"
+                if (Test-Path -LiteralPath $deletePath) {
+                        Write-Output "Deleting $deletePath"
+                        Remove-Item -LiteralPath $deletePath -Force -Recurse
+                }
+
+                $deletePath2 = "${override_Path_DevSuite}:\vbs2\customer\structures\$project_name\"
+                if (Test-Path -LiteralPath $deletePath2) {
+                        Write-Output "Deleting $deletePath2"
+                        Remove-Item -LiteralPath $deletePath2 -Force -Recurse
+                }
+
+                Write-Output "Cleaned files before creating new ones"
+        }
 
         #Delete existing settings and create new file in the shared Input folder
-        $projectFolder = Join-Path $inputRoot $project_name
-        New-Item -ItemType Directory -Path $projectFolder -Force | Out-Null
+        $projectFolder = Normalize-UNCPath (SafeJoin $inputRoot $project_name)
+        Ensure-Directory $projectFolder
 
-        $generated_settings_file = Join-Path $projectFolder "$project_name.txt"
-        if ((Test-Path $generated_settings_file)) {
-                Remove-Item -Path $generated_settings_file
+        $generated_settings_file = Normalize-UNCPath (SafeJoin $projectFolder "$project_name.txt")
+        if (Test-Path -LiteralPath $generated_settings_file) {
+                Remove-Item -LiteralPath $generated_settings_file
         }
-	
-	$override_Installation_VBS4_bool = "false"
-	if ($override_Installation_VBS4 -eq 1) {
-		$override_Installation_VBS4_bool = "true"
-	}
+
+        $override_Installation_VBS4_bool = "false"
+        if ($override_Installation_VBS4 -eq 1) {
+                $override_Installation_VBS4_bool = "true"
+        }
 
         $timestamp = Get-Date -Format 'yyyyMMdd_HHmmss'
         $out_in_name = "$project_name"
-        $out_in_name_with_drive = Join-Path $outputRoot "${project_name}_$timestamp"
-        New-Item -ItemType Directory -Path $out_in_name_with_drive -Force | Out-Null
-	
-	New-Item -Path $generated_settings_file -ItemType File
-	Add-Content -Path $generated_settings_file -Value "set name {$project_name}"
-	Add-Content -Path $generated_settings_file -Value "set blender_path {$blender_path}"
-	Add-Content -Path $generated_settings_file -Value "set blender_threads {$blender_threads}"
-	Add-Content -Path $generated_settings_file -Value "set override_Installation_VBS4_bool {$override_Installation_VBS4_bool}"
-	Add-Content -Path $generated_settings_file -Value "set override_Path_VBS4 {$override_Path_VBS4}"
-	Add-Content -Path $generated_settings_file -Value "set vbs4_version {$vbs4_version}"
-	Add-Content -Path $generated_settings_file -Value "set override_Installation_DevSuite {$override_Installation_DevSuite}"
-	Add-Content -Path $generated_settings_file -Value "set override_Path_DevSuite {$override_Path_DevSuite}"
-	Add-Content -Path $generated_settings_file -Value "set offset_x {$offset_x}"
-	Add-Content -Path $generated_settings_file -Value "set offset_y {$offset_y}"
-	Add-Content -Path $generated_settings_file -Value "set offset_z {$offset_z}"
-	Add-Content -Path $generated_settings_file -Value "set offset_coordsys {$offset_coordsys}"
-	Add-Content -Path $generated_settings_file -Value "set offset_hdatum {$offset_hdatum}"
-	Add-Content -Path $generated_settings_file -Value "set offset_vdatum {$offset_vdatum}"
-	Add-Content -Path $generated_settings_file -Value "set orthocam_Resolution {$orthocam_Resolution}"
-	Add-Content -Path $generated_settings_file -Value "set orthocam_Render_Lowest {$orthocam_Render_Lowest}"
-	Add-Content -Path $generated_settings_file -Value "set tin_to_dem_Resolution {$tin_to_dem_Resolution}"
-	Add-Content -Path $generated_settings_file -Value "set override_Installation_VBS4 {$override_Installation_VBS4}"
-	Add-Content -Path $generated_settings_file -Value "set sel_Area_Size {$sel_Area_Size}"
-	Add-Content -Path $generated_settings_file -Value "set out_in_name {$out_in_name}"
-	Add-Content -Path $generated_settings_file -Value "set out_in_name_with_drive {$out_in_name_with_drive}"
-	Add-Content -Path $generated_settings_file -Value "set collision {$collision}"
-	Add-Content -Path $generated_settings_file -Value "set visualLODs {$visualLODs}"
-	Add-Content -Path $generated_settings_file -Value "set project_vdatum {$project_vdatum}"
-	Add-Content -Path $generated_settings_file -Value "set offset_models {$offset_models}"
-	Add-Content -Path $generated_settings_file -Value "set csf_options {$csf_options}"
-	Add-Content -Path $generated_settings_file -Value "set faceThresh {$faceThresh}"
-	Add-Content -Path $generated_settings_file -Value "set lodThresh {$lodThresh}"
-	Add-Content -Path $generated_settings_file -Value "set tileSize {$tileSize}"
-	Add-Content -Path $generated_settings_file -Value "set srfResolution {$srfResolution}"
-	
+        $out_in_name_with_drive = Normalize-UNCPath (SafeJoin $outputRoot "${project_name}_$timestamp")
+        Ensure-Directory $out_in_name_with_drive
+
+        Write-Output "ProjectName: $project_name"
+        Write-Output "DestDir: $out_in_name_with_drive"
+        Write-Output "GeneratedSettingsFile: $generated_settings_file"
+
+        New-Item -ItemType File -Path $generated_settings_file -Force | Out-Null
+        Add-Content -LiteralPath $generated_settings_file -Value "set name {$project_name}"
+        Add-Content -LiteralPath $generated_settings_file -Value "set blender_path {$blender_path}"
+        Add-Content -LiteralPath $generated_settings_file -Value "set blender_threads {$blender_threads}"
+        Add-Content -LiteralPath $generated_settings_file -Value "set override_Installation_VBS4_bool {$override_Installation_VBS4_bool}"
+        Add-Content -LiteralPath $generated_settings_file -Value "set override_Path_VBS4 {$override_Path_VBS4}"
+        Add-Content -LiteralPath $generated_settings_file -Value "set vbs4_version {$vbs4_version}"
+        Add-Content -LiteralPath $generated_settings_file -Value "set override_Installation_DevSuite {$override_Installation_DevSuite}"
+        Add-Content -LiteralPath $generated_settings_file -Value "set override_Path_DevSuite {$override_Path_DevSuite}"
+        Add-Content -LiteralPath $generated_settings_file -Value "set offset_x {$offset_x}"
+        Add-Content -LiteralPath $generated_settings_file -Value "set offset_y {$offset_y}"
+        Add-Content -LiteralPath $generated_settings_file -Value "set offset_z {$offset_z}"
+        Add-Content -LiteralPath $generated_settings_file -Value "set offset_coordsys {$offset_coordsys}"
+        Add-Content -LiteralPath $generated_settings_file -Value "set offset_hdatum {$offset_hdatum}"
+        Add-Content -LiteralPath $generated_settings_file -Value "set offset_vdatum {$offset_vdatum}"
+        Add-Content -LiteralPath $generated_settings_file -Value "set orthocam_Resolution {$orthocam_Resolution}"
+        Add-Content -LiteralPath $generated_settings_file -Value "set orthocam_Render_Lowest {$orthocam_Render_Lowest}"
+        Add-Content -LiteralPath $generated_settings_file -Value "set tin_to_dem_Resolution {$tin_to_dem_Resolution}"
+        Add-Content -LiteralPath $generated_settings_file -Value "set override_Installation_VBS4 {$override_Installation_VBS4}"
+        Add-Content -LiteralPath $generated_settings_file -Value "set sel_Area_Size {$sel_Area_Size}"
+        Add-Content -LiteralPath $generated_settings_file -Value "set out_in_name {$out_in_name}"
+        Add-Content -LiteralPath $generated_settings_file -Value "set out_in_name_with_drive {$out_in_name_with_drive}"
+        Add-Content -LiteralPath $generated_settings_file -Value "set collision {$collision}"
+        Add-Content -LiteralPath $generated_settings_file -Value "set visualLODs {$visualLODs}"
+        Add-Content -LiteralPath $generated_settings_file -Value "set project_vdatum {$project_vdatum}"
+        Add-Content -LiteralPath $generated_settings_file -Value "set offset_models {$offset_models}"
+        Add-Content -LiteralPath $generated_settings_file -Value "set csf_options {$csf_options}"
+        Add-Content -LiteralPath $generated_settings_file -Value "set faceThresh {$faceThresh}"
+        Add-Content -LiteralPath $generated_settings_file -Value "set lodThresh {$lodThresh}"
+        Add-Content -LiteralPath $generated_settings_file -Value "set tileSize {$tileSize}"
+        Add-Content -LiteralPath $generated_settings_file -Value "set srfResolution {$srfResolution}"
+
         $command_path = $generated_settings_file
 
         # Copy the project template files from the repository location.
@@ -245,17 +300,17 @@ if ($AREYOUSURE -eq 'y') {
         # Use the previously resolved RealityMesh template path
         $templatePath = $RealityMeshTTPath
         $destinationPath = $projectFolder
-        if (Test-Path $templatePath) {
-                robocopy $templatePath $destinationPath
+        if (Test-Path -LiteralPath $templatePath) {
+                robocopy "$templatePath" "$destinationPath" | Out-Null
         }
         else {
                 Write-Output "Template folder not found at $templatePath"
                 Return
         }
-	
-        Set-Location -Path $destinationPath
 
-        Rename-Item -Path "RealityMeshProcess.ttp" -NewName "$project_name.ttp"
+        Set-Location -LiteralPath $destinationPath
+
+        Rename-Item -LiteralPath "RealityMeshProcess.ttp" -NewName "$project_name.ttp"
 
         "set sourceDir `"$source_Directory`" " | Out-File sourceDir.txt -Encoding Default
         "set tileScheme `"$tile_scheme`" " | Out-File tileScheme.txt -Encoding Default
@@ -301,7 +356,7 @@ if ($AREYOUSURE -eq 'y') {
         "Time to run TT project: $minutes minutes" | Out-File TimingLog.txt -Encoding Default
 
         # Signal completion for remote monitors
-        $doneFile = Join-Path $out_in_name_with_drive 'DONE.txt'
+        $doneFile = Normalize-UNCPath (SafeJoin $out_in_name_with_drive 'DONE.txt')
         New-Item -ItemType File -Path $doneFile -Force | Out-Null
         Write-Output "Created $doneFile"
 } 


### PR DESCRIPTION
## Summary
- add helpers to normalize UNC paths, sanitize names and ensure directories
- build project and output paths using SafeJoin and quote all file operations
- derive project name from Output-CenterPivotOrigin.json when possible and log resolved paths

## Testing
- `pwsh -NoLogo -NoProfile -Command "[System.Management.Automation.Language.Parser]::ParseFile('PythonPorjects/photomesh/RealityMeshProcess.ps1',[ref]$null,[ref]$null)"` *(command not found)*
- `apt-get install -y powershell` *(package unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_689a2c00537483229f167fbece0a6796