### PR TITLE
Use Start-Process with PowerShell for remote RealityMesh invocation

### DIFF
--- a/PythonPorjects/photomesh/Invoke-RemoteRealityMesh.ps1
+++ b/PythonPorjects/photomesh/Invoke-RemoteRealityMesh.ps1
@@ -40,10 +40,14 @@ try {
     Write-Host "Launching RealityMeshProcess.ps1 on $TargetIP" -ForegroundColor Cyan
     Invoke-Command -Session $session -ScriptBlock {
         param($script, $settings)
-        # Show a visible command window on the remote machine with a status
+        # Show a visible PowerShell window on the remote machine with a status
         # message so users know processing is running.
-        $args = "/c start cmd /k \"echo RealityMeshProcess in progress do not turn off pc && powershell -ExecutionPolicy Bypass -File `"$script`" `"$settings`"\""
-        Start-Process -FilePath cmd.exe -ArgumentList $args
+        $msg = 'RealityMeshProcess in progress — do not turn off PC'
+        Start-Process -FilePath 'powershell.exe' -ArgumentList @(
+            '-NoExit',
+            '-ExecutionPolicy','Bypass',
+            '-Command', "Write-Host '$msg' -ForegroundColor Yellow; & '$script' '$settings' 1"
+        )
     } -ArgumentList $scriptPath, $remoteSettings
 }
 finally {


### PR DESCRIPTION
## Summary
- avoid cmd.exe quoting issues by launching RealityMeshProcess via Start-Process and PowerShell

## Testing
- `pwsh -NoLogo -NoProfile -Command "[System.Management.Automation.Language.Parser]::ParseFile('PythonPorjects/photomesh/Invoke-RemoteRealityMesh.ps1',[ref]([System.Management.Automation.Language.Token[]]@()),[ref]([System.Management.Automation.Language.ParseError[]]@()))"`

------
https://chatgpt.com/codex/tasks/task_e_689a322d97cc83228cc009283927b79d

## Summary by Sourcery

Use Start-Process with PowerShell to launch the remote RealityMeshProcess and avoid cmd.exe quoting issues

Bug Fixes:
- Resolve quoting issues when invoking the remote script via cmd.exe

Enhancements:
- Launch a visible PowerShell window on the remote machine with a status message instead of using cmd.exe
- Pass script and settings arguments directly to PowerShell with -NoExit and -ExecutionPolicy Bypass