### PR TITLE
Add production-ready remote RealityMesh launcher

### DIFF
--- a/PythonPorjects/photomesh/Invoke-RemoteRealityMesh.ps1
+++ b/PythonPorjects/photomesh/Invoke-RemoteRealityMesh.ps1
@@ -10,15 +10,19 @@
       - <ProjectFolder>.txt
  ===================================================================== #>
 
-[CmdletBinding()]
+[CmdletBinding(DefaultParameterSetName='ByFolder')]
 param(
     # Remote PC IP or hostname
-    [Parameter(Mandatory=$true, Position=0)]
+    [Parameter(Mandatory, Position=0)]
     [string]$Target,
 
-    # Project folder name under ...\RealityMesh\Input\ (omit to auto-pick latest)
-    [Parameter(Position=1)]
+    # ByFolder: caller gives a project folder name (omit to auto-pick latest)
+    [Parameter(ParameterSetName='ByFolder', Position=1)]
     [string]$ProjectFolder,
+
+    # BySettings: caller gives a full path to the settings file
+    [Parameter(ParameterSetName='BySettings', Mandatory, Position=1)]
+    [string]$SettingsFile,
 
     # Root UNC share for RealityMesh
     [Parameter(Position=2)]
@@ -54,21 +58,40 @@ $OutputRoot = Join-Path $ShareRoot 'Output'
 if (-not (Test-Path $InputRoot))  { throw "Input root not found: $InputRoot" }
 if (-not (Test-Path $OutputRoot)) { New-Item -ItemType Directory -Path $OutputRoot -Force | Out-Null }
 
-# Auto-pick latest project folder if not provided
-if (-not $ProjectFolder) {
-    $latest = Get-ChildItem -Path $InputRoot -Directory |
-              Sort-Object LastWriteTime -Descending | Select-Object -First 1
-    if (-not $latest) { throw "No project directories found under $InputRoot" }
-    $ProjectFolder = $latest.Name
-    Log "Auto-selected latest project folder: $ProjectFolder"
+if ($PSCmdlet.ParameterSetName -eq 'BySettings') {
+    try {
+        $resolvedSettings = (Resolve-Path -LiteralPath $SettingsFile -ErrorAction Stop).ProviderPath
+    } catch {
+        throw "Settings file not found: $SettingsFile"
+    }
+
+    $ProjectFolder = Split-Path -LeafBase $resolvedSettings
+    $ProjectPathUNC = Join-Path $InputRoot $ProjectFolder
+    $destTxt = Join-Path $ProjectPathUNC ("{0}.txt" -f $ProjectFolder)
+    $srcDir = Split-Path -Parent $resolvedSettings
+
+    if ($srcDir.TrimEnd('\') -ieq $ProjectPathUNC.TrimEnd('\')) {
+        $TxtPath = $resolvedSettings
+    } else {
+        if (-not (Test-Path $ProjectPathUNC)) { New-Item -ItemType Directory -Path $ProjectPathUNC -Force | Out-Null }
+        Copy-Item -LiteralPath $resolvedSettings -Destination $destTxt -Force
+        $TxtPath = $destTxt
+        Log "Copied settings file to $TxtPath"
+    }
+} else {
+    if (-not $ProjectFolder) {
+        $latest = Get-ChildItem -Path $InputRoot -Directory |
+                  Sort-Object LastWriteTime -Descending | Select-Object -First 1
+        if (-not $latest) { throw "No project directories found under $InputRoot" }
+        $ProjectFolder = $latest.Name
+        Log "Auto-selected latest project folder: $ProjectFolder"
+    }
+    $ProjectPathUNC = Join-Path $InputRoot $ProjectFolder
+    $TxtPath = Join-Path $ProjectPathUNC ("{0}.txt" -f $ProjectFolder)
 }
 
-$ProjectPathUNC = Join-Path $InputRoot $ProjectFolder
 if (-not (Test-Path $ProjectPathUNC)) { throw "Project folder not found: $ProjectPathUNC" }
-
-# Expect: RealityMeshProcess.ps1 + <ProjectFolder>.txt
 $Ps1Path = Join-Path $ProjectPathUNC 'RealityMeshProcess.ps1'
-$TxtPath = Join-Path $ProjectPathUNC ("{0}.txt" -f $ProjectFolder)
 if (-not (Test-Path $Ps1Path)) { throw "Process script not found: $Ps1Path" }
 if (-not (Test-Path $TxtPath)) { throw "Settings file not found: $TxtPath" }
 
@@ -86,59 +109,66 @@ if (-not $Credential) {
 # Normalize username for workgroup/local if not Domain\User format
 $user = $Credential.UserName
 if ($user -notmatch '^[^\\]+\\[^\\]+$') { $user = ".\${user}" }
-
-# PsExec requires plaintext password; zero it after use
+ 
+# PsExec requires plaintext password; zero it in finally
 $ptr = [Runtime.InteropServices.Marshal]::SecureStringToBSTR($Credential.Password)
-try { $plain = [Runtime.InteropServices.Marshal]::PtrToStringBSTR($ptr) } finally { [Runtime.InteropServices.Marshal]::ZeroFreeBSTR($ptr) }
+try {
+    $plain = [Runtime.InteropServices.Marshal]::PtrToStringBSTR($ptr)
 
-# ------------------- Preflight: ADMIN$ access -------------------
-Log "Testing ADMIN$ on \\$Target..."
-$netUse = cmd /c "net use \\$Target\ADMIN$ /user:$user $plain"
-if ($LASTEXITCODE -ne 0) {
-    Log "ADMIN$ test failed. Output:"
-    Log $netUse
-    throw "Cannot access \\$Target\ADMIN$ as $user. Enable File & Printer Sharing, ensure local admin + token policy, or fix creds."
+    # ------------------- Preflight: ADMIN$ access -------------------
+    Log "Testing ADMIN$ on \\$Target..."
+    $netCmd = "net use \\$Target\ADMIN$ /user:$user `"$plain`""
+    $netUse = cmd /c $netCmd
+    if ($LASTEXITCODE -ne 0) {
+        Log "ADMIN$ test failed. Output:"
+        Log $netUse
+        throw "Cannot access \\$Target\ADMIN$ as $user. Enable File & Printer Sharing, ensure account is in local Administrators group, and set LocalAccountTokenFilterPolicy=1."
+    }
+    # Clean mapping
+    cmd /c "net use \\$Target\ADMIN$ /delete" | Out-Null
+
+    # -------- build the remote command safely --------
+    $escapedPs1 = $Ps1Path.Replace("'", "''").Replace('`','``')
+    $escapedTxt = $TxtPath.Replace("'", "''").Replace('`','``')
+    $banner = if ($NoBanner) { "" } else { "Write-Host 'RealityMeshProcess in progress - do not turn off PC' -ForegroundColor Yellow; " }
+    $remoteCmd = ("{0}& '{1}' '{2}' 1" -f $banner, $escapedPs1, $escapedTxt)
+
+    # ---- PsExec args ----
+    $psArgs = @(
+        "\\$Target", "-i", "-h",
+        "-u", $user, "-p", $plain,
+        "powershell", "-NoExit", "-ExecutionPolicy", "Bypass",
+        "-Command", $remoteCmd
+    )
+
+    Log "Starting remote PowerShell window..."
+    $psi = New-Object System.Diagnostics.ProcessStartInfo
+    $psi.FileName               = $PsExecPath
+    $psi.Arguments              = ($psArgs | ForEach-Object {
+        if ($_ -match '\s|;|&|\(|\)|\^|\|' ) { '"{0}"' -f $_ } else { $_ }
+    }) -join ' '
+    $psi.UseShellExecute        = $false
+    $psi.RedirectStandardOutput = $true
+    $psi.RedirectStandardError  = $true
+
+    $proc = [System.Diagnostics.Process]::Start($psi)
+    $stdout = $proc.StandardOutput.ReadToEnd()
+    $stderr = $proc.StandardError.ReadToEnd()
+    $proc.WaitForExit()
+
+    if ($stdout) { Log $stdout.Trim() }
+    if ($stderr) { Log ("STDERR: " + $stderr.Trim()) }
+
+    if ($proc.ExitCode -ne 0) {
+        throw "PsExec returned exit code $($proc.ExitCode). See log for details."
+    }
+
+    Log "Remote window launched. Operators can watch progress on $Target."
 }
-# Clean mapping
-cmd /c "net use \\$Target\ADMIN$ /delete" | Out-Null
-
-# -------- build the remote command safely --------
-$escapedPs1 = $Ps1Path.Replace("'", "''").Replace('`','``')
-$escapedTxt = $TxtPath.Replace("'", "''").Replace('`','``')
-$banner = if ($NoBanner) { "" } else { "Write-Host 'RealityMeshProcess in progress - do not turn off PC' -ForegroundColor Yellow; " }
-$remoteCmd = ("{0}& '{1}' '{2}' 1" -f $banner, $escapedPs1, $escapedTxt)
-
-# ---- PsExec args (this was missing) ----
-$psArgs = @(
-    "\\$Target", "-i", "-h",
-    "-u", $user, "-p", $plain,
-    "powershell", "-NoExit", "-ExecutionPolicy", "Bypass",
-    "-Command", $remoteCmd
-)
-
-Log "Starting remote PowerShell window..."
-$psi = New-Object System.Diagnostics.ProcessStartInfo
-$psi.FileName               = $PsExecPath
-$psi.Arguments              = ($psArgs | ForEach-Object {
-    if ($_ -match '\s|;|&|\(|\)|\^|\|' ) { '"{0}"' -f $_ } else { $_ }
-}) -join ' '
-$psi.UseShellExecute        = $false
-$psi.RedirectStandardOutput = $true
-$psi.RedirectStandardError  = $true
-
-$proc = [System.Diagnostics.Process]::Start($psi)
-$stdout = $proc.StandardOutput.ReadToEnd()
-$stderr = $proc.StandardError.ReadToEnd()
-$proc.WaitForExit()
-
-if ($stdout) { Log $stdout.Trim() }
-if ($stderr) { Log ("STDERR: " + $stderr.Trim()) }
-
-[System.Array]::Clear([char[]]$plain, 0, $plain.Length) 2>$null
-$plain = $null
-
-if ($proc.ExitCode -ne 0) {
-    throw "PsExec returned exit code $($proc.ExitCode). See log for details."
+finally {
+    if ($ptr) { [Runtime.InteropServices.Marshal]::ZeroFreeBSTR($ptr) }
+    if ($plain) {
+        [System.Array]::Clear([char[]]$plain, 0, $plain.Length) 2>$null
+        $plain = $null
+    }
 }
-
-Log "Remote window launched. Operators can watch progress on $Target."


### PR DESCRIPTION
## Summary
- handle settings file paths in Invoke-RemoteRealityMesh to launch projects via folder or settings file
- maintain logging, credential handling, and PsExec invocation

## Testing
- `pwsh -NoLogo -Command '$cred=New-Object System.Management.Automation.PSCredential("user",(ConvertTo-SecureString "pass" -AsPlainText -Force)); & "PythonPorjects/photomesh/Invoke-RemoteRealityMesh.ps1" 192.168.10.201 -ProjectFolder CACTF_BUILD -ShareRoot "$(pwd)/testshare" -NoBanner -Credential $cred' 2>&1 | head -n 40`
- `pwsh -NoLogo -Command '$cred=New-Object System.Management.Automation.PSCredential("user",(ConvertTo-SecureString "pass" -AsPlainText -Force)); & "PythonPorjects/photomesh/Invoke-RemoteRealityMesh.ps1" 192.168.10.201 -SettingsFile "$(pwd)/localSettings/CACTF_BUILD-settings.txt" -ShareRoot "$(pwd)/testshare" -NoBanner -Credential $cred' 2>&1 | head -n 40`
- `pwsh -NoLogo -Command '$cred=New-Object System.Management.Automation.PSCredential("user",(ConvertTo-SecureString "pass" -AsPlainText -Force)); & "PythonPorjects/photomesh/Invoke-RemoteRealityMesh.ps1" 192.168.10.201 -SettingsFile "$(pwd)/testshare/Input/CACTF_BUILD/CACTF_BUILD.txt" -ShareRoot "$(pwd)/testshare" -NoBanner -Credential $cred' 2>&1 | head -n 40`


------
https://chatgpt.com/codex/tasks/task_e_689a497b9edc8322bf6eb6a4320d854c