### PR TITLE
Automate Reality Mesh runner with BAT handoff

### DIFF
--- a/PythonPorjects/photomesh/Invoke-RemoteRealityMesh.ps1
+++ b/PythonPorjects/photomesh/Invoke-RemoteRealityMesh.ps1
@@ -165,7 +165,7 @@ try {
                   "$('New-Item -ItemType Directory -Force -Path ''{0}'' | Out-Null;' -f $escapedDir)" +
                   "$('Start-Transcript -Path ''{0}'' -Append;' -f $escapedLog)" +
                   "try { " +
-                  "$(' & ''{0}'' ''{1}'' 1; ' -f $escapedPs1, $escapedTxt)" +
+                  "$(' & ''{0}'' ''{1}''; ' -f $escapedPs1, $escapedTxt)" +
                   " } finally { Stop-Transcript } }"
 
     # ---- PsExec args (HEADLESS: no -i, DETACHED: -d, run elevated: -h) ----


### PR DESCRIPTION
## Summary
- add BAT workflow variables and non-interactive defaults
- auto-rename existing project folders and preflight source models
- generate BAT key=value settings, run BAT by default or fallback to TCL, update remote invocation script

## Testing
- `apt-get install -y powershell` *(fails: Unable to locate package powershell)*
- `pwsh -Version` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689b769ac98c8322a7605617b66536c8

## Summary by Sourcery

Automate the RealityMeshProcess PowerShell workflow by integrating BAT handoff, enforcing non-interactive defaults and preflight validations, auto-renaming projects, cleaning up temp directories, and refining the remote invocation script.

New Features:
- Integrate a BAT-based runner into the RealityMeshProcess script with auto-generated key=value settings and fallback to the legacy TCL runner
- Enable non-interactive mode by default with fail-fast checks for missing project and system settings
- Auto-rename existing project folders by appending a timestamp and record the new name in a helper file
- Automate cleanup of DevSuite temporary directories for each project
- Preflight the source directory to ensure presence of .obj or .las files before processing

Enhancements:
- Replace interactive prompts and confirmation steps with exceptions and standardized error handling

Chores:
- Update Invoke-RemoteRealityMesh.ps1 to adjust remote invocation parameters for the PowerShell script