### PR TITLE
Handle RealityMeshProcess script path correctly

### DIFF
--- a/PythonPorjects/photomesh/RealityMeshProcess.bat
+++ b/PythonPorjects/photomesh/RealityMeshProcess.bat
@@ -6,6 +6,7 @@ if "%~1"=="" (
 )
 set "SETTINGS_FILE=%~1"
 echo Using settings: %SETTINGS_FILE%
-powershell -executionpolicy bypass -File ".\RealityMeshProcess.ps1" "%SETTINGS_FILE%"
+REM Use the directory of this batch file to locate the PowerShell script
+powershell -executionpolicy bypass -File "%~dp0RealityMeshProcess.ps1" "%SETTINGS_FILE%"
 exit /b %errorlevel%
 


### PR DESCRIPTION
## Summary
- call RealityMeshProcess.ps1 using the batch file's directory so the script runs even if started from other folders

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689b87aed6dc8322adab2ec133370906

## Summary by Sourcery

Bug Fixes:
- Fix RealityMeshProcess.bat to invoke the PowerShell script using its own directory path