### PR TITLE
Fix RealityMesh BAT root path

### DIFF
--- a/PythonPorjects/photomesh/RealityMeshProcess.ps1
+++ b/PythonPorjects/photomesh/RealityMeshProcess.ps1
@@ -49,7 +49,8 @@ function SafeJoin {
 }
 
 # ---------- BAT integration ----------
-$RemoteBatchRoot = "C:\Users\User\Documents\BiSim\Datasets_and_Template\Template"  # folder that contains the BAT
+# Use the script's directory as the root that contains the BAT file.
+$RemoteBatchRoot = $PSScriptRoot
 $RemoteBatchFile = "RealityMeshProcess.bat"                                        # BAT filename
 [bool]$UseTclDirect = $false  # when true, use old TCL path; default is BAT mode
 


### PR DESCRIPTION
## Summary
- Use the script's directory as `RemoteBatchRoot` so the runner can find `RealityMeshProcess.bat`

## Testing
- `pwsh -NoLogo -File PythonPorjects/photomesh/RealityMeshProcess.ps1 "PythonPorjects/photomesh/project (20250812_140956)-settings.txt"` *(fails: `pwsh` not found)*
- `apt-get install -y powershell` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_689b8985c6088322a43e8f2f9baf8d4b

## Summary by Sourcery

Bug Fixes:
- Replace hard-coded RemoteBatchRoot with $PSScriptRoot to dynamically locate RealityMeshProcess.bat