### PR TITLE
Harden quoting and path handling

### DIFF
--- a/PythonPorjects/photomesh/RealityMeshProcess.ps1
+++ b/PythonPorjects/photomesh/RealityMeshProcess.ps1
@@ -1,10 +1,25 @@
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+[Console]::OutputEncoding = [System.Text.Encoding]::UTF8
+$errors = $null
+$tokens = $null
+$ast = [System.Management.Automation.Language.Parser]::ParseFile($PSCommandPath, [ref]$tokens, [ref]$errors)
+if ($errors -and $errors.Count -gt 0) {
+  Write-Error ('Self-parse check failed at line {0}: {1}' -f $errors[0].Extent.StartLineNumber, $errors[0].Message)
+  exit 2
+}
+
+[CmdletBinding()]
+param(
+  [Parameter(Mandatory=$true, Position=0)]
+  [string]$SettingsFile,
+  [Parameter(Position=1)]
+  [string]$FullyAutomate = '1'
+)
+
 # =========================
 # Reality Mesh Runner (fixed UNC + robust paths)
 # =========================
-
-# Argument parsing
-$project_settings_File = $args[0]
-$fully_automate = $args[1]
 
 # ---------- Helpers ----------
 function Normalize-UNCPath {
@@ -65,24 +80,21 @@ Ensure-Directory $inputRoot
 Ensure-Directory $outputRoot
 
 # ---------- Prompt/defaults ----------
-if ([string]::IsNullOrEmpty($project_settings_File)) {
-    throw "Project settings file path is required. Pass it as the first arg."
-}
-$fully_automate = 1
-$project_settings_File = Normalize-UNCPath ($project_settings_File.Trim('"'))
+$SettingsFile = Normalize-UNCPath ($SettingsFile.Trim('"'))
 
 # ---------- Settings Parsing ----------
-$system_settings = "$PSScriptRoot/RealityMeshSystemSettings.txt"
+$system_settings = Join-Path $PSScriptRoot 'RealityMeshSystemSettings.txt'
 
-if (-not (Test-Path -LiteralPath $project_settings_File)) {
-    throw "project settings file does not exist: $project_settings_File"
+if (-not (Test-Path -LiteralPath $SettingsFile)) {
+    throw ('project settings file does not exist: {0}' -f $SettingsFile)
 }
 
 if (-not (Test-Path -LiteralPath $system_settings)) {
-    throw "System settings file does not exist: $system_settings"
+    throw ('System settings file does not exist: {0}' -f $system_settings)
 }
 
-Write-Host "Project and System settings found" -ForegroundColor Green
+Write-Output ('Using settings: {0}' -f $SettingsFile)
+Write-Host 'Project and System settings found' -ForegroundColor Green
 
 # Determine the location of the RealityMesh_tt template folder.
 $RealityMeshTTPath = Join-Path $PSScriptRoot 'RealityMesh_tt'
@@ -91,51 +103,51 @@ if (-not (Test-Path -LiteralPath $RealityMeshTTPath)) {
     if (Test-Path -LiteralPath $defaultRealityMeshTTPath) {
         $RealityMeshTTPath = $defaultRealityMeshTTPath
     } else {
-        throw "RealityMesh_tt folder not found at '$RealityMeshTTPath' or '$defaultRealityMeshTTPath'"
+        throw ("RealityMesh_tt folder not found at '{0}' or '{1}'" -f $RealityMeshTTPath, $defaultRealityMeshTTPath)
     }
 }
 
 # ---------- Project settings ----------
-$project_name = Sanitize-Name ((Get-Content -LiteralPath $project_settings_File | Where-Object { $_ -match "^project_name=" }) -replace "project_name=", "")
-$source_Directory_temp = (Get-Content -LiteralPath $project_settings_File | Where-Object { $_ -match "^source_Directory=" }) -replace "source_Directory=", ""
+$project_name = Sanitize-Name ((Get-Content -LiteralPath $SettingsFile | Where-Object { $_ -match "^project_name=" }) -replace "project_name=", "")
+$source_Directory_temp = (Get-Content -LiteralPath $SettingsFile | Where-Object { $_ -match "^source_Directory=" }) -replace "source_Directory=", ""
 $source_Directory = Normalize-UNCPath $source_Directory_temp
 
 # Validate data folder
 if (-not (Test-Path -LiteralPath $source_Directory)) {
-    throw "source_Directory not found: $source_Directory"
+    throw ('source_Directory not found: {0}' -f $source_Directory)
 }
 $objFiles = @(Get-ChildItem -Path $source_Directory -Filter *.obj -Recurse -ErrorAction SilentlyContinue)
 $lasFiles = @(Get-ChildItem -Path $source_Directory -Filter *.las -Recurse -ErrorAction SilentlyContinue)
 $objCount = $objFiles.Count
 $lasCount = $lasFiles.Count
-Write-Output "Data folder: $source_Directory — Found $objCount OBJ, $lasCount LAS"
+Write-Output ('Data folder: {0} — Found {1} OBJ, {2} LAS' -f $source_Directory, $objCount, $lasCount)
 if ($objCount -eq 0 -and $lasCount -eq 0) {
-    throw "No *.obj/*.las found under: $source_Directory. Make sure your data folder points to the correct location."
+    throw ('No *.obj/*.las found under: {0}. Make sure your data folder points to the correct location.' -f $source_Directory)
 }
 
 # Locate Output-CenterPivotOrigin.json if available
 $ocpo = Get-ChildItem -Path $source_Directory -Filter "Output-CenterPivotOrigin.json" -Recurse -ErrorAction SilentlyContinue | Select-Object -First 1
 
-$sel_Area_Size         = (Get-Content -LiteralPath $project_settings_File | Where-Object { $_ -match "^sel_Area_Size=" }) -replace "sel_Area_Size=", ""
-$offset_coordsys       = (Get-Content -LiteralPath $project_settings_File | Where-Object { $_ -match "^offset_coordsys=" }) -replace "offset_coordsys=", ""
-$offset_hdatum         = (Get-Content -LiteralPath $project_settings_File | Where-Object { $_ -match "^offset_hdatum=" }) -replace "offset_hdatum=", ""
-$offset_vdatum         = (Get-Content -LiteralPath $project_settings_File | Where-Object { $_ -match "^offset_vdatum=" }) -replace "offset_vdatum=", ""
-$offset_x              = (Get-Content -LiteralPath $project_settings_File | Where-Object { $_ -match "^offset_x=" }) -replace "offset_x=", ""
-$offset_y              = (Get-Content -LiteralPath $project_settings_File | Where-Object { $_ -match "^offset_y=" }) -replace "offset_y=", ""
-$offset_z              = (Get-Content -LiteralPath $project_settings_File | Where-Object { $_ -match "^offset_z=" }) -replace "offset_z=", ""
-$orthocam_Resolution   = (Get-Content -LiteralPath $project_settings_File | Where-Object { $_ -match "^orthocam_Resolution=" }) -replace "orthocam_Resolution=", ""
-$orthocam_Render_Lowest= (Get-Content -LiteralPath $project_settings_File | Where-Object { $_ -match "^orthocam_Render_Lowest=" }) -replace "orthocam_Render_Lowest=", ""
-$tin_to_dem_Resolution = (Get-Content -LiteralPath $project_settings_File | Where-Object { $_ -match "^tin_to_dem_Resolution=" }) -replace "tin_to_dem_Resolution=", ""
-$tile_scheme           = (Get-Content -LiteralPath $project_settings_File | Where-Object { $_ -match "^tile_scheme=" }) -replace "tile_scheme=", ""
-$collision             = (Get-Content -LiteralPath $project_settings_File | Where-Object { $_ -match "^collision=" }) -replace "collision=", ""
-$visualLODs            = (Get-Content -LiteralPath $project_settings_File | Where-Object { $_ -match "^visualLODs=" }) -replace "visualLODs=", ""
-$project_vdatum        = (Get-Content -LiteralPath $project_settings_File | Where-Object { $_ -match "^project_vdatum=" }) -replace "project_vdatum=", ""
-$offset_models         = (Get-Content -LiteralPath $project_settings_File | Where-Object { $_ -match "^offset_models=" }) -replace "offset_models=", ""
-$csf_options           = (Get-Content -LiteralPath $project_settings_File | Where-Object { $_ -match "^csf_options=" }) -replace "csf_options=", ""
-$faceThresh            = (Get-Content -LiteralPath $project_settings_File | Where-Object { $_ -match "^faceThresh=" }) -replace "faceThresh=", ""
-$lodThresh             = (Get-Content -LiteralPath $project_settings_File | Where-Object { $_ -match "^lodThresh=" }) -replace "lodThresh=", ""
-$tileSize              = (Get-Content -LiteralPath $project_settings_File | Where-Object { $_ -match "^tileSize=" }) -replace "tileSize=", ""
-$srfResolution         = (Get-Content -LiteralPath $project_settings_File | Where-Object { $_ -match "^srfResolution=" }) -replace "srfResolution=", ""
+$sel_Area_Size         = (Get-Content -LiteralPath $SettingsFile | Where-Object { $_ -match "^sel_Area_Size=" }) -replace "sel_Area_Size=", ""
+$offset_coordsys       = (Get-Content -LiteralPath $SettingsFile | Where-Object { $_ -match "^offset_coordsys=" }) -replace "offset_coordsys=", ""
+$offset_hdatum         = (Get-Content -LiteralPath $SettingsFile | Where-Object { $_ -match "^offset_hdatum=" }) -replace "offset_hdatum=", ""
+$offset_vdatum         = (Get-Content -LiteralPath $SettingsFile | Where-Object { $_ -match "^offset_vdatum=" }) -replace "offset_vdatum=", ""
+$offset_x              = (Get-Content -LiteralPath $SettingsFile | Where-Object { $_ -match "^offset_x=" }) -replace "offset_x=", ""
+$offset_y              = (Get-Content -LiteralPath $SettingsFile | Where-Object { $_ -match "^offset_y=" }) -replace "offset_y=", ""
+$offset_z              = (Get-Content -LiteralPath $SettingsFile | Where-Object { $_ -match "^offset_z=" }) -replace "offset_z=", ""
+$orthocam_Resolution   = (Get-Content -LiteralPath $SettingsFile | Where-Object { $_ -match "^orthocam_Resolution=" }) -replace "orthocam_Resolution=", ""
+$orthocam_Render_Lowest= (Get-Content -LiteralPath $SettingsFile | Where-Object { $_ -match "^orthocam_Render_Lowest=" }) -replace "orthocam_Render_Lowest=", ""
+$tin_to_dem_Resolution = (Get-Content -LiteralPath $SettingsFile | Where-Object { $_ -match "^tin_to_dem_Resolution=" }) -replace "tin_to_dem_Resolution=", ""
+$tile_scheme           = (Get-Content -LiteralPath $SettingsFile | Where-Object { $_ -match "^tile_scheme=" }) -replace "tile_scheme=", ""
+$collision             = (Get-Content -LiteralPath $SettingsFile | Where-Object { $_ -match "^collision=" }) -replace "collision=", ""
+$visualLODs            = (Get-Content -LiteralPath $SettingsFile | Where-Object { $_ -match "^visualLODs=" }) -replace "visualLODs=", ""
+$project_vdatum        = (Get-Content -LiteralPath $SettingsFile | Where-Object { $_ -match "^project_vdatum=" }) -replace "project_vdatum=", ""
+$offset_models         = (Get-Content -LiteralPath $SettingsFile | Where-Object { $_ -match "^offset_models=" }) -replace "offset_models=", ""
+$csf_options           = (Get-Content -LiteralPath $SettingsFile | Where-Object { $_ -match "^csf_options=" }) -replace "csf_options=", ""
+$faceThresh            = (Get-Content -LiteralPath $SettingsFile | Where-Object { $_ -match "^faceThresh=" }) -replace "faceThresh=", ""
+$lodThresh             = (Get-Content -LiteralPath $SettingsFile | Where-Object { $_ -match "^lodThresh=" }) -replace "lodThresh=", ""
+$tileSize              = (Get-Content -LiteralPath $SettingsFile | Where-Object { $_ -match "^tileSize=" }) -replace "tileSize=", ""
+$srfResolution         = (Get-Content -LiteralPath $SettingsFile | Where-Object { $_ -match "^srfResolution=" }) -replace "srfResolution=", ""
 
 # Override offsets from Output-CenterPivotOrigin.json and derive project name
 if ($ocpo) {
@@ -180,7 +192,7 @@ if ($ocpo) {
         if ($null -eq $tmp) { $tmp = $json.vdatum }
         if ($null -ne $tmp) { $offset_vdatum = $tmp }
     } catch {
-        Write-Warning "Failed to parse offsets from $($ocpo.FullName): $_"
+        Write-Warning ('Failed to parse offsets from {0}: {1}' -f $ocpo.FullName, $_)
     }
 }
 
@@ -190,7 +202,7 @@ $default_blender = "C:\Program Files\Blender Foundation\Blender 4.5\blender.exe"
 if (!(Test-Path -LiteralPath $blender_path)) {
     if (Test-Path -LiteralPath $default_blender) {
         $blender_path = $default_blender
-        Write-Output "Using Blender found at $blender_path"
+        Write-Output ('Using Blender found at {0}' -f $blender_path)
     } else {
         $search = Get-ChildItem "C:\Program Files\Blender Foundation" -Directory -ErrorAction SilentlyContinue |
             Sort-Object Name -Descending |
@@ -199,9 +211,9 @@ if (!(Test-Path -LiteralPath $blender_path)) {
             Select-Object -First 1
         if ($search) {
             $blender_path = $search
-            Write-Output "Using Blender found at $blender_path"
+            Write-Output ('Using Blender found at {0}' -f $blender_path)
         } else {
-            throw "Blender Path invalid"
+            throw 'Blender Path invalid'
         }
     }
 }
@@ -209,7 +221,7 @@ $blender_threads               = (Get-Content -LiteralPath $system_settings | Wh
 $override_Installation_VBS4    = (Get-Content -LiteralPath $system_settings | Where-Object { $_ -match "^override_Installation_VBS4=" }) -replace "override_Installation_VBS4=", ""
 $override_Path_VBS4            = (Get-Content -LiteralPath $system_settings | Where-Object { $_ -match "^override_Path_VBS4=" }) -replace "override_Path_VBS4=", ""
 if (($override_Installation_VBS4 -eq 1) -and !(Test-Path -LiteralPath $override_Path_VBS4)) {
-    throw "VBS4 path invalid"
+    throw 'VBS4 path invalid'
 }
 $vbs4_version                  = (Get-Content -LiteralPath $system_settings | Where-Object { $_ -match "^vbs4_version=" }) -replace "vbs4_version=", ""
 $override_Installation_DevSuite= (Get-Content -LiteralPath $system_settings | Where-Object { $_ -match "^override_Installation_DevSuite=" }) -replace "override_Installation_DevSuite=", ""
@@ -217,34 +229,36 @@ $override_Path_DevSuite        = (Get-Content -LiteralPath $system_settings | Wh
 $terratools_home_path          = (Get-Content -LiteralPath $system_settings | Where-Object { $_ -match "^terratools_home_path=" }) -replace "terratools_home_path=", ""
 $terratools_ssh_path           = (Get-Content -LiteralPath $system_settings | Where-Object { $_ -match "^terratools_ssh_path=" }) -replace "terratools_ssh_path=", ""
 if (!(Test-Path -LiteralPath $terratools_ssh_path)) {
-    throw "Terratools Path invalid: $terratools_ssh_path"
+    throw ('Terratools Path invalid: {0}' -f $terratools_ssh_path)
 }
 
 # ---------- Handle project name conflicts ----------
 if (Test-Path (Join-Path $inputRoot $project_name)) {
-    $project_name = "{0}_{1}" -f $project_name, (Get-Date -Format "yyyyMMdd_HHmmss")
+    $project_name = ('{0}_{1}' -f $project_name, (Get-Date -Format 'yyyyMMdd_HHmmss'))
 }
-Ensure-Directory "$PSScriptRoot\ProjectSettings\GeneratedFiles_DoNotEdit"
-New-Item -Path "$PSScriptRoot\ProjectSettings\GeneratedFiles_DoNotEdit\AutomationHelper.txt" -ItemType "File" -Value "$project_name" -Force | Out-Null
+$genDir = Join-Path $PSScriptRoot 'ProjectSettings'
+$genDir = Join-Path $genDir 'GeneratedFiles_DoNotEdit'
+Ensure-Directory $genDir
+New-Item -Path (Join-Path $genDir 'AutomationHelper.txt') -ItemType File -Value $project_name -Force | Out-Null
 
 # ---------- Cleanup DevSuite temp ----------
-$deletePath  = "${override_Path_DevSuite}:\temp\RealityMesh\$project_name\"
+$deletePath  = Join-Path ('{0}:\temp\RealityMesh' -f $override_Path_DevSuite) $project_name
 if (Test-Path -LiteralPath $deletePath) {
-    Write-Output "Deleting $deletePath"
+    Write-Output ('Deleting {0}' -f $deletePath)
     Remove-Item -LiteralPath $deletePath -Force -Recurse
 }
-$deletePath2 = "${override_Path_DevSuite}:\vbs2\customer\structures\$project_name\"
+$deletePath2 = Join-Path ('{0}:\vbs2\customer\structures' -f $override_Path_DevSuite) $project_name
 if (Test-Path -LiteralPath $deletePath2) {
-    Write-Output "Deleting $deletePath2"
+    Write-Output ('Deleting {0}' -f $deletePath2)
     Remove-Item -LiteralPath $deletePath2 -Force -Recurse
 }
-Write-Output "Cleaned files before creating new ones"
+Write-Output 'Cleaned files before creating new ones'
 
 # ---------- Build generated settings & output destinations ----------
 $projectFolder = Join-Path $inputRoot $project_name
 Ensure-Directory $projectFolder
 
-$generated_settings_file = Join-Path $projectFolder "$project_name.txt"
+$generated_settings_file = Join-Path $projectFolder ('{0}.txt' -f $project_name)
 if (Test-Path -LiteralPath $generated_settings_file) {
     Remove-Item -LiteralPath $generated_settings_file -Force
 }
@@ -252,13 +266,14 @@ if (Test-Path -LiteralPath $generated_settings_file) {
 $override_Installation_VBS4_bool = if ($override_Installation_VBS4 -eq 1) { "true" } else { "false" }
 
 $timestamp = Get-Date -Format 'yyyyMMdd_HHmmss'
-$out_in_name = "$project_name"
-$out_in_name_with_drive = Join-Path $outputRoot "${project_name}_$timestamp"
-Ensure-Directory $out_in_name_with_drive
+$out_in_name = $project_name
+$OutputDir = Join-Path $outputRoot ('{0}_{1}' -f $project_name, $timestamp)
+Ensure-Directory $OutputDir
+$out_in_name_with_drive = $OutputDir
 
-Write-Output "ProjectName: $project_name"
-Write-Output "DestDir: $out_in_name_with_drive"
-Write-Output "GeneratedSettingsFile: $generated_settings_file"
+Write-Output ('ProjectName: {0}' -f $project_name)
+Write-Output ('DestDir: {0}' -f $OutputDir)
+Write-Output ('GeneratedSettingsFile: {0}' -f $generated_settings_file)
 
 # Create settings file
 New-Item -ItemType File -Path $generated_settings_file -Force | Out-Null
@@ -322,7 +337,7 @@ $kvLines = @(
 $kvLines | Out-File -LiteralPath $kvSettingsLocal -Encoding UTF8 -Force
 
 # Place settings on top of the BAT folder
-if (-not (Test-Path -LiteralPath $RemoteBatchRoot)) { throw "BAT root not found: $RemoteBatchRoot" }
+if (-not (Test-Path -LiteralPath $RemoteBatchRoot)) { throw ('BAT root not found: {0}' -f $RemoteBatchRoot) }
 $BatSettingsPath = Join-Path $RemoteBatchRoot ("{0}-settings.txt" -f $project_name)
 Copy-Item -LiteralPath $kvSettingsLocal -Destination $BatSettingsPath -Force
 
@@ -332,11 +347,9 @@ $command_path = $generated_settings_file
 $templatePath = $RealityMeshTTPath
 $destinationPath = $projectFolder
 if (Test-Path -LiteralPath $templatePath) {
-    $rc = @('robocopy', ('"'+$templatePath+'"'), ('"'+$destinationPath+'"'),
-            '*.*','/E','/DCOPY:DA','/COPY:DAT','/R:3','/W:5') -join ' '
-    cmd /c $rc | Out-Host
+    & robocopy $templatePath $destinationPath *.* /E /DCOPY:DA /COPY:DAT /R:3 /W:5 | Out-Host
 } else {
-    throw "Template folder not found at $templatePath"
+    throw ('Template folder not found at {0}' -f $templatePath)
 }
 
 Set-Location -LiteralPath $destinationPath
@@ -344,9 +357,9 @@ Set-Location -LiteralPath $destinationPath
 # Rename .ttp safely
 $ttp = Join-Path $destinationPath 'RealityMeshProcess.ttp'
 if (Test-Path -LiteralPath $ttp) {
-    Rename-Item -LiteralPath $ttp -NewName "$project_name.ttp" -Force
+    Rename-Item -LiteralPath $ttp -NewName ('{0}.ttp' -f $project_name) -Force
 } else {
-    Write-Warning "Template .ttp not found at $ttp"
+    Write-Warning ('Template .ttp not found at {0}' -f $ttp)
 }
 
 # Write small config files
@@ -356,60 +369,60 @@ if (Test-Path -LiteralPath $ttp) {
 # Ensure n33.tbr exists before running the main TCL script
 $n33File = Join-Path $destinationPath 'n33.tbr'
 if (-not (Test-Path -LiteralPath $n33File)) {
-    Write-Host "n33.tbr not found. Generating with TSG_TBR_to_Vertex_Points_Unique.tcl..." -ForegroundColor Yellow
+Write-Host 'n33.tbr not found. Generating with TSG_TBR_to_Vertex_Points_Unique.tcl...' -ForegroundColor Yellow
 
     $ttScript  = Join-Path $destinationPath 'TSG_TBR_to_Vertex_Points_Unique.tcl'
     $inputTbr  = Join-Path $destinationPath 'n32.tbr'
     $ttShell   = $terratools_ssh_path
 
     if (Test-Path -LiteralPath $inputTbr) {
-        $ttArgs = "`"$ttScript`" `"$inputTbr`" `"$n33File`""
+        $ttArgs = @($ttScript, $inputTbr, $n33File)
         $proc   = Start-Process -FilePath $ttShell -ArgumentList $ttArgs -NoNewWindow -Wait -PassThru
 
         if ($proc.ExitCode -ne 0) {
-            Write-Host "Failed to generate n33.tbr via TerraTools" -ForegroundColor Red
+            Write-Host 'Failed to generate n33.tbr via TerraTools' -ForegroundColor Red
         }
     } else {
-        Write-Host "Required input TBR not found: $inputTbr" -ForegroundColor Red
+        Write-Host ('Required input TBR not found: {0}' -f $inputTbr) -ForegroundColor Red
     }
 }
 
 if (-not (Test-Path -LiteralPath $n33File)) {
-    Write-Host "ERROR: Required file n33.tbr could not be created." -ForegroundColor Red
-    throw "Required file n33.tbr could not be created"
+    Write-Host 'ERROR: Required file n33.tbr could not be created.' -ForegroundColor Red
+    throw 'Required file n33.tbr could not be created'
 }
 
 # TERRATOOLS_HOME override
 if (!([string]::IsNullOrEmpty($terratools_home_path)) -and (Test-Path -LiteralPath $terratools_home_path)) {
-    Write-Output "Using custom TERRATOOLS_HOME path at $terratools_home_path"
+    Write-Output ('Using custom TERRATOOLS_HOME path at {0}' -f $terratools_home_path)
     $env:TERRASIM_HOME = $terratools_home_path
 }
 
 # ---------- Run the process ----------
 if (-not $UseTclDirect) {
     $batPath = Join-Path $RemoteBatchRoot $RemoteBatchFile
-    if (-not (Test-Path -LiteralPath $batPath)) { throw "BAT not found: $batPath" }
-    Write-Host "Starting Reality Mesh BAT..." -ForegroundColor Cyan
+    if (-not (Test-Path -LiteralPath $batPath)) { throw ('BAT not found: {0}' -f $batPath) }
+    Write-Host 'Starting Reality Mesh BAT...' -ForegroundColor Cyan
     $startTime = Get-Date
     $p = Start-Process -FilePath $batPath -NoNewWindow -PassThru
     $p.WaitForExit()
     if ($LASTEXITCODE -ne 0 -and $p.ExitCode -ne 0) {
-        throw "Reality Mesh BAT returned code $($p.ExitCode)"
+        throw ('Reality Mesh BAT returned code {0}' -f $p.ExitCode)
     }
     $minutes = ((Get-Date) - $startTime).TotalSeconds / 60
     "Time to run BAT: $minutes minutes" | Out-File -LiteralPath (Join-Path $destinationPath 'TimingLog.txt') -Encoding Default -Append
 } else {
-    Write-Host "Launching RealityMeshProcess.tcl with settings from $command_path" -ForegroundColor Cyan
-    Write-Host "🚧 Processing Reality Mesh... Please wait. Do not close this window." -ForegroundColor Yellow
+    Write-Host ('Launching RealityMeshProcess.tcl with settings from {0}' -f $command_path) -ForegroundColor Cyan
+    Write-Host '🚧 Processing Reality Mesh... Please wait. Do not close this window.' -ForegroundColor Yellow
     Start-Sleep -Seconds 2
 
     $startTime = Get-Date
-    $proc = Start-Process -FilePath "$terratools_ssh_path" -NoNewWindow -PassThru -ArgumentList "RealityMeshProcess.tcl -command_file `"$command_path`""
+    $proc = Start-Process -FilePath $terratools_ssh_path -NoNewWindow -PassThru -ArgumentList @('RealityMeshProcess.tcl','-command_file',$command_path)
     $spinner = '/-\|'
     $i = 0
     while (-not $proc.HasExited) {
         $char = $spinner[$i % $spinner.Length]
-        Write-Host -NoNewline "`r$char Processing..."
+        Write-Host -NoNewline ("`r{0} Processing..." -f $char)
         Start-Sleep -Seconds 1
         $i++
     }
@@ -417,12 +430,12 @@ if (-not $UseTclDirect) {
     Write-Host "`rProcessing complete.             "
     $time = (Get-Date) - $startTime
     $minutes = $time.TotalSeconds / 60
-    Write-Output "`nTime to run TT project: $minutes minutes"
+    Write-Output ('`nTime to run TT project: {0} minutes' -f $minutes)
     "Time to run TT project: $minutes minutes" | Out-File -LiteralPath (Join-Path $destinationPath 'TimingLog.txt') -Encoding Default -Append
 }
 
 # ---------- Signal completion for remote monitors ----------
-$doneFile = Join-Path $out_in_name_with_drive 'DONE.txt'
+$doneFile = Join-Path $OutputDir 'DONE.txt'
 New-Item -ItemType File -Path $doneFile -Force | Out-Null
-Write-Output ("Created {0}" -f $doneFile)
+Write-Output ('Created {0}' -f $doneFile)
 


### PR DESCRIPTION
## Summary
- add strict mode, fail-fast defaults, and self-parse preflight
- replace ad-hoc args with param block and safe "Using settings" log
- sanitize output paths and DONE.txt creation

## Testing
- `powershell -NoProfile -Command "$PSVersionTable.PSVersion"` *(fails: command not found)*
- `apt-get install -y powershell` *(fails: Unable to locate package powershell)*

------
https://chatgpt.com/codex/tasks/task_e_689e06278f348322bcadf0c903e0a895

## Summary by Sourcery

Harden quoting and path handling by enabling strict mode, replacing ad-hoc argument parsing with a proper parameter block, normalizing and sanitizing UNC paths via Join-Path, standardizing string formatting for logging and errors, and improving file operations (robocopy, cleanup, DONE.txt creation).

New Features:
- Enable strict PowerShell mode and stop-on-error behavior with a self-parse preflight check
- Introduce a CmdletBinding parameter block for settings file and automation flag

Bug Fixes:
- Fix quoting issues in error messages and file operations to handle spaces and special characters

Enhancements:
- Normalize and sanitize all UNC and output paths using Normalize-UNCPath and Join-Path
- Replace ad-hoc argument parsing and string concatenation with formal parameters and format operator
- Standardize logging and error messages via Write-Output/Host with parameterized formatting
- Simplify robocopy invocation and streamline directory setup and cleanup operations
- Ensure safe creation of DONE.txt and generated settings files