### PR TITLE
Handle UTF-8 PowerShell output

### DIFF
--- a/PythonPorjects/STE_Toolkit.py
+++ b/PythonPorjects/STE_Toolkit.py
@@ -623,10 +623,19 @@ def run_remote_processor(ps_script: str, target_ip: str, settings_path: str,
         settings_path,
     ]
     log_func('Running: ' + ' '.join(cmd))
-    with subprocess.Popen(cmd, stdout=subprocess.PIPE,
-                          stderr=subprocess.STDOUT, text=True) as proc:
+    env = os.environ.copy()
+    env["PYTHONIOENCODING"] = "utf-8"
+    with subprocess.Popen(
+        cmd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        env=env,
+    ) as proc:
         for line in proc.stdout:
-            line = line.rstrip()
+            line = line.rstrip("\r\n")
             log_func(line)
             percent = extract_progress(line)
             if percent is not None:
@@ -3032,13 +3041,23 @@ class VBS4Panel(tk.Frame):
                         'powershell',
                         '-ExecutionPolicy', 'Bypass',
                         '-File', ps_script,
-                        settings_path 
+                        settings_path
                     ]
                     self.log_message('Running: ' + ' '.join(cmd))
                     self.set_progress(0)
-                    with subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True) as proc:
+                    env = os.environ.copy()
+                    env["PYTHONIOENCODING"] = "utf-8"
+                    with subprocess.Popen(
+                        cmd,
+                        stdout=subprocess.PIPE,
+                        stderr=subprocess.STDOUT,
+                        text=True,
+                        encoding="utf-8",
+                        errors="replace",
+                        env=env,
+                    ) as proc:
                         for line in proc.stdout:
-                            line = line.rstrip()
+                            line = line.rstrip("\r\n")
                             self.log_message(line)
                             percent = extract_progress(line)
                             if percent is not None:
@@ -3116,9 +3135,19 @@ class VBS4Panel(tk.Frame):
             ]
             self.log_message('Running: ' + ' '.join(cmd))
             self.set_progress(0)
-            with subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True) as proc:
+            env = os.environ.copy()
+            env["PYTHONIOENCODING"] = "utf-8"
+            with subprocess.Popen(
+                cmd,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+                env=env,
+            ) as proc:
                 for line in proc.stdout:
-                    line = line.rstrip()
+                    line = line.rstrip("\r\n")
                     self.log_message(line)
                     percent = extract_progress(line)
                     if percent is not None:

--- a/PythonPorjects/photomesh/RealityMeshRunner.ps1
+++ b/PythonPorjects/photomesh/RealityMeshRunner.ps1
@@ -10,6 +10,8 @@ param(
   [switch]$PackageOnly
 )
 $EffectivePackageOnly = $PackageOnly -or ($env:RM_PACKAGE_ONLY -eq '1')
+[Console]::OutputEncoding = [System.Text.Encoding]::UTF8
+$OutputEncoding = [System.Text.Encoding]::UTF8
 
 # ---- helpers ----
 function Normalize-UNCPath {

--- a/PythonPorjects/reality_mesh_gui.py
+++ b/PythonPorjects/reality_mesh_gui.py
@@ -238,9 +238,19 @@ def run_processor(ps_script: str, settings_path: str, log_fn, progress_cb):
         '1'
     ]
     log_fn('Running: ' + ' '.join(cmd))
-    with subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True) as proc:
+    env = os.environ.copy()
+    env["PYTHONIOENCODING"] = "utf-8"
+    with subprocess.Popen(
+        cmd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        env=env,
+    ) as proc:
         for line in proc.stdout:
-            line = line.rstrip()
+            line = line.rstrip("\r\n")
             log_fn(line)
             percent = extract_progress(line)
             if percent is not None:
@@ -262,9 +272,19 @@ def run_remote_processor(ps_script: str, target_ip: str, settings_path: str, log
         settings_path,
     ]
     log_fn('Running: ' + ' '.join(cmd))
-    with subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True) as proc:
+    env = os.environ.copy()
+    env["PYTHONIOENCODING"] = "utf-8"
+    with subprocess.Popen(
+        cmd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        env=env,
+    ) as proc:
         for line in proc.stdout:
-            line = line.rstrip()
+            line = line.rstrip("\r\n")
             log_fn(line)
             percent = extract_progress(line)
             if percent is not None:


### PR DESCRIPTION
## Summary
- force UTF-8 decoding and tolerate bad bytes when streaming PowerShell output in GUI
- set PowerShell's output encoding to UTF-8

## Testing
- `python -m py_compile PythonPorjects/STE_Toolkit.py PythonPorjects/reality_mesh_gui.py`


------
https://chatgpt.com/codex/tasks/task_e_689e157fcf908322a6c58f8270c5548a