### PR TITLE
Prevent infinite PS-BAT recursion by detecting second stage

### DIFF
--- a/PythonPorjects/photomesh/RealityMeshProcess.bat
+++ b/PythonPorjects/photomesh/RealityMeshProcess.bat
@@ -1,12 +1,7 @@
 @echo off
 setlocal
-if "%~1"=="" (
-  echo ERROR: missing settings file path
-  exit /b 2
-)
-set "SETTINGS_FILE=%~1"
-echo Using settings: %SETTINGS_FILE%
-REM Use the directory of this batch file to locate the PowerShell script
-powershell -executionpolicy bypass -File "%~dp0RealityMeshProcess.ps1" "%SETTINGS_FILE%"
+REM %~dp0 is the BAT folder; PS script sits next to it.
+powershell -ExecutionPolicy Bypass -File "%~dp0RealityMeshProcess.ps1" "%~1"
+endlocal
 exit /b %errorlevel%
 


### PR DESCRIPTION
## Summary
- detect when the PowerShell script is invoked from the BAT file and skip re-launching the BAT
- run TerraTools directly in second stage and append optional DONE marker
- simplify batch file to call the PowerShell script once

## Testing
- `pwsh -NoProfile -Command "[System.Management.Automation.Language.Parser]::ParseFile('PythonPorjects/photomesh/RealityMeshProcess.ps1',[ref]$null,[ref]$null) | Out-Null"` *(fails: command not found)*
- `apt-get install -y powershell` *(fails: Unable to locate package powershell)*

------
https://chatgpt.com/codex/tasks/task_e_689e22993c088322b6ead5848c3d0329