### PR TITLE
Ensure project names are sanitized consistently

### DIFF
--- a/PythonPorjects/photomesh/RealityMeshRunner.ps1
+++ b/PythonPorjects/photomesh/RealityMeshRunner.ps1
@@ -23,7 +23,8 @@ function Normalize-UNCPath {
 }
 function Sanitize-Name {
   param([Parameter(Mandatory)][string]$Name)
-  $n = $Name -replace '[\/:*?"<>|]', '_' ; $n = $n.Trim().TrimEnd('.')
+  $n = $Name -replace '[\/:*?"<>|()]', '_'
+  $n = $n.Trim().TrimEnd('.')
   if ([string]::IsNullOrWhiteSpace($n)) { $n = 'Project' }
   return $n
 }


### PR DESCRIPTION
## Summary
- Sanitize project names in the Reality Mesh runner to replace parentheses just like stage-2

## Testing
- `powershell -NoLogo -NoProfile -Command "Write-Output 'test'"` *(command not found)*
- `sudo apt-get install -y powershell` *(unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_689f34f65db48322bdb2ed4b93dfc179

## Summary by Sourcery

Enhancements:
- Include parentheses in the set of characters replaced with underscores in the Sanitize-Name function.