### PR TITLE
Integrate external Reality Mesh app

### DIFF
--- a/PythonPorjects/photomesh/RealityMeshSystemSettings.txt
+++ b/PythonPorjects/photomesh/RealityMeshSystemSettings.txt
@@ -11,3 +11,4 @@ terratools_home_path=C:\Program Files\Bohemia Interactive Simulations\TerraTools
 dataset_root=C:\BiSim OneClick\Datasets
 export_format=OBJ
 center_pivot_to_project=true
+reality_mesh_to_vbs4_path=C:\Bohemia Interactive Simulations\Reality Mesh to VBS4 25.1\Reality Mesh to VBS4.lnk

--- a/RealityMeshSystemSettings.txt
+++ b/RealityMeshSystemSettings.txt
@@ -12,3 +12,4 @@ terratools_home_path=C:\Program Files\Bohemia Interactive Simulations\TerraTools
 dataset_root=C:\BiSim OneClick\Datasets
 export_format=OBJ
 center_pivot_to_project=true
+reality_mesh_to_vbs4_path=C:\Bohemia Interactive Simulations\Reality Mesh to VBS4 25.1\Reality Mesh to VBS4.lnk


### PR DESCRIPTION
## Summary
- Replace Post-Process stage with external "Reality Mesh to VBS4" application
- Auto-detect Reality Mesh shortcut and expose launch helper
- Add configuration entry for Reality Mesh to VBS4 path

## Testing
- `python -m py_compile PythonPorjects/STE_Toolkit.py`


------
https://chatgpt.com/codex/tasks/task_e_689f524310848322b7252ceecf74aaaa

## Summary by Sourcery

Replace the internal photo-mesh post-processing workflow with a launch of an external Reality Mesh to VBS4 application, including auto-discovery of the launcher, configurable path settings, and updated UI elements.

New Features:
- Launch external Reality Mesh to VBS4 application instead of in-app post-processing
- Auto-detect Reality Mesh to VBS4 shortcut and support custom path via configuration entry

Enhancements:
- Add helper to locate the Reality Mesh to VBS4 shortcut file
- Rename and repurpose the post-process UI button and update log messages and dialogs accordingly