### PR TITLE
Open shared mesh drive when build directory missing

### DIFF
--- a/PythonPorjects/STE_Toolkit.py
+++ b/PythonPorjects/STE_Toolkit.py
@@ -2979,8 +2979,16 @@ class VBS4Panel(tk.Frame):
         if build_root:
             self.last_build_dir = build_root
         if not self.last_build_dir:
-            self.log_message("No build directory available to launch Reality Mesh.")
-            return
+            shared_drive = r"\\HAMMERKIT1-4\SharedMeshDrive"
+            self.log_message(
+                "No build directory available to launch Reality Mesh. "
+                "Opening shared drive instead."
+            )
+            try:
+                os.startfile(shared_drive)
+            except Exception as exc:
+                self.log_message(f"Failed to open shared drive: {exc}")
+            self.last_build_dir = shared_drive
 
         try:
             self._launch_reality_mesh_app(self.last_build_dir)


### PR DESCRIPTION
## Summary
- Default to `\\HAMMERKIT1-4\SharedMeshDrive` when no build directory exists and open it automatically

## Testing
- `python -m py_compile PythonPorjects/STE_Toolkit.py`


------
https://chatgpt.com/codex/tasks/task_e_689f604fe89c8322b753348b5584d35d

## Summary by Sourcery

Provide a fallback to open a shared mesh drive and continue launching the Reality Mesh app when no build directory is available

New Features:
- Open the default network shared mesh drive when no build directory is found

Enhancements:
- Log a message and attempt to open the shared drive automatically as a fallback
- Catch and log exceptions when opening the shared drive