### PR TITLE
Handle Reality Mesh shortcut arguments correctly

### DIFF
--- a/PythonPorjects/STE_Toolkit.py
+++ b/PythonPorjects/STE_Toolkit.py
@@ -3019,8 +3019,13 @@ class VBS4Panel(tk.Frame):
         # Launch without any "started" popup
         self.log_message(f"Launching: {link}" + (f' "{build_root}"' if build_root else ""))
         try:
-            # Prefer subprocess for argument passing; os.startfile(args=...) is Python 3.10+ and not always reliable.
-            subprocess.Popen(cmd, close_fds=True)
+            # If a Windows shortcut (.lnk) is used, pass the build directory via os.startfile
+            # so it isn't opened separately in Explorer.
+            if build_root and link.lower().endswith(".lnk"):
+                os.startfile(link, arguments=f'"{build_root}"')
+            else:
+                # Prefer subprocess for argument passing to executables.
+                subprocess.Popen(cmd, close_fds=True)
         except Exception:
             # Last-resort fallback
             os.startfile(link)


### PR DESCRIPTION
## Summary
- Avoid opening build directory in Explorer when launching Reality Mesh to VBS4 via Windows shortcut
- Pass build directory as arguments using `os.startfile` when `.lnk` is used

## Testing
- `python -m py_compile STE_Toolkit.py`


------
https://chatgpt.com/codex/tasks/task_e_689f64b72b708322ae6c59d3425dd1f9

## Summary by Sourcery

Update launcher logic to correctly handle Windows shortcut (.lnk) arguments when starting Reality Mesh, avoiding unwanted Explorer windows and preserving subprocess invocation for executables.

Bug Fixes:
- Prevent opening the build directory in Explorer when launching Reality Mesh via a .lnk shortcut by passing the directory argument to os.startfile.

Enhancements:
- Use os.startfile with arguments for .lnk shortcuts while continuing to use subprocess.Popen for direct executable launches.