### PR TITLE
Launch Reality Mesh app without opening File Explorer

### DIFF
--- a/PythonPorjects/STE_Toolkit.py
+++ b/PythonPorjects/STE_Toolkit.py
@@ -2978,20 +2978,11 @@ class VBS4Panel(tk.Frame):
         sys_settings_path = os.path.join(BASE_DIR, 'photomesh', 'RealityMeshSystemSettings.txt')
         if build_root:
             self.last_build_dir = build_root
-        if not self.last_build_dir:
-            shared_drive = r"\\HAMMERKIT1-4\SharedMeshDrive"
-            self.log_message(
-                "No build directory available to launch Reality Mesh. "
-                "Opening shared drive instead."
-            )
-            try:
-                os.startfile(shared_drive)
-            except Exception as exc:
-                self.log_message(f"Failed to open shared drive: {exc}")
-            self.last_build_dir = shared_drive
-
         try:
-            self._launch_reality_mesh_app(self.last_build_dir)
+            # Launch the application directly without opening a file explorer
+            # window first. If no build directory is available, start without
+            # passing a path.
+            self._launch_reality_mesh_app(self.last_build_dir if self.last_build_dir else None)
         except Exception as exc:
             self.log_message(f"Launch failed: {exc}")
             messagebox.showerror("Error", str(exc), parent=self)


### PR DESCRIPTION
## Summary
- Launch Reality Mesh to VBS4 application directly without opening a File Explorer window first

## Testing
- `pytest`
- `python -m py_compile PythonPorjects/STE_Toolkit.py`


------
https://chatgpt.com/codex/tasks/task_e_68a327c3587c83229a21b1838e794bf5

## Summary by Sourcery

Modify post_process_last_build to launch the Reality Mesh application directly without opening a File Explorer window and simplify the handling of missing build directories.

Enhancements:
- Remove fallback behavior that opened the shared drive in File Explorer when no build directory was available
- Always invoke _launch_reality_mesh_app, passing None if the build directory is missing