### PR TITLE
Automate Reality Mesh launch in one-click terrain workflow

### DIFF
--- a/PythonPorjects/STE_Toolkit.py
+++ b/PythonPorjects/STE_Toolkit.py
@@ -2957,16 +2957,17 @@ class VBS4Panel(tk.Frame):
                     "Build Error", str(exc), parent=self))
                 return
 
-            try:
-                self.log_message("Launching Reality Mesh to VBS4...")
-                self._launch_reality_mesh_app(self.last_build_dir)
-            except Exception as exc:
-                self.log_message(f"Launch failed: {exc}")
-                self.after(0, lambda: messagebox.showerror(
-                    "Launch Error", str(exc), parent=self))
-                return
+            def launch_rm():
+                try:
+                    self.log_message("Launching Reality Mesh to VBS4...")
+                    self.post_process_last_build(self.last_build_dir)
+                    self.log_message("Reality Mesh to VBS4 launched.")
+                except Exception as exc:
+                    self.log_message(f"Launch failed: {exc}")
+                    messagebox.showerror("Launch Error", str(exc), parent=self)
 
-            self.log_message("Reality Mesh to VBS4 launched.")
+            # Schedule the Reality Mesh launch on the main thread
+            self.after(0, launch_rm)
 
         run_in_thread(_pipeline)
 


### PR DESCRIPTION
## Summary
- Ensure One-Click Terrain Conversion launches Reality Mesh to VBS4 after PhotoMesh build completion
- Schedule the Reality Mesh launch on the main thread via `post_process_last_build`

## Testing
- `python -m py_compile PythonPorjects/STE_Toolkit.py`


------
https://chatgpt.com/codex/tasks/task_e_68a32b12972c8322a1edda953a16e3db

## Summary by Sourcery

Automate and defer the Reality Mesh application launch to the main thread using the post_process_last_build callback after completing the PhotoMesh build.

New Features:
- Automatically trigger Reality Mesh launch to VBS4 after PhotoMesh build in the one-click terrain workflow

Enhancements:
- Schedule the Reality Mesh launch on the main GUI thread via post_process_last_build and self.after instead of direct invocation