### PR TITLE
Handle network path selection in imagery picker

### DIFF
--- a/PythonPorjects/STE_Toolkit.py
+++ b/PythonPorjects/STE_Toolkit.py
@@ -2673,14 +2673,28 @@ class VBS4Panel(tk.Frame):
         folder_listbox.pack(pady=10)
 
         def add_folder():
-            path = simpledialog.askstring(
+            input_path = simpledialog.askstring(
                 "Network Path",
                 "Enter network folder path (leave blank to browse):",
                 parent=folder_window,
             )
-            if path and os.path.exists(path):
-                found = get_image_folders_recursively(clean_path(path))
-                folders.extend(found)
+            if input_path:
+                path = clean_path(input_path)
+                if os.path.isdir(path):
+                    selected = filedialog.askdirectory(
+                        title="Select DCIM or base imagery folder",
+                        initialdir=path,
+                        parent=folder_window,
+                    )
+                    if selected:
+                        found = get_image_folders_recursively(clean_path(selected))
+                        folders.extend(found)
+                else:
+                    messagebox.showerror(
+                        "Invalid Path",
+                        f"The path '{input_path}' does not exist.",
+                        parent=folder_window,
+                    )
             else:
                 selected = filedialog.askdirectory(
                     title="Select DCIM or base imagery folder", parent=folder_window


### PR DESCRIPTION
## Summary
- Allow imagery selection dialog to open at a user-specified network path.
- Show an error when the provided path doesn't exist.

## Testing
- `python -m py_compile PythonPorjects/STE_Toolkit.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a342c1627c8322a10c109e8225bedf

## Summary by Sourcery

Allow user to enter a network path as the starting folder in the imagery selection dialog, and display an error if the path is invalid.

New Features:
- Enable specifying an initial network folder path for imagery selection
- Validate the user-provided network path and show an error if it does not exist