### PR TITLE
Ensure uniform VBS4 panel buttons

### DIFF
--- a/PythonPorjects/STE_Toolkit.py
+++ b/PythonPorjects/STE_Toolkit.py
@@ -1038,11 +1038,18 @@ def get_image_folders_recursively(base_folder):
     return image_folders
 
 def create_app_button(parent, app_name, get_path_func, launch_func, set_path_func):
+    """Create a launch button with an optional path setter and version label.
+
+    The button and its version label are stacked vertically and expand to the
+    width of the parent so that all buttons can share a uniform size.  The
+    caller can hide the returned version label if it is not needed.
+    """
+
     frame = tk.Frame(parent, bg="#333333")
-    frame.pack(pady=8)
+    frame.pack(pady=8, fill="x")
 
     path = clean_path(get_path_func())
-    
+
     if not path or not os.path.exists(path):
         state = "disabled"
         bg_color = "#888888"
@@ -1050,8 +1057,11 @@ def create_app_button(parent, app_name, get_path_func, launch_func, set_path_fun
         state = "normal"
         bg_color = "#444444"
 
+    btn_frame = tk.Frame(frame, bg="#333333")
+    btn_frame.pack(fill="x")
+
     button = tk.Button(
-        frame,
+        btn_frame,
         text=f"Launch {app_name}",
         font=("Helvetica", 20),
         bg=bg_color,
@@ -1059,11 +1069,11 @@ def create_app_button(parent, app_name, get_path_func, launch_func, set_path_fun
         state=state,
         command=launch_func
     )
-    button.pack(side=tk.LEFT, ipadx=10, ipady=5)
+    button.pack(side=tk.LEFT, fill="x", expand=True, ipadx=10, ipady=5)
 
     if state == "disabled":
         question_button = tk.Button(
-            frame,
+            btn_frame,
             text="?",
             font=("Helvetica", 16, "bold"),
             bg="orange",
@@ -1072,7 +1082,7 @@ def create_app_button(parent, app_name, get_path_func, launch_func, set_path_fun
         )
         question_button.pack(side=tk.LEFT, padx=(5, 0))
 
-    # Version label
+    # Version label placed beneath the button
     version_label = tk.Label(
         frame,
         text="",
@@ -1080,7 +1090,7 @@ def create_app_button(parent, app_name, get_path_func, launch_func, set_path_fun
         bg="#333333",
         fg="white"
     )
-    version_label.pack(side=tk.LEFT, padx=10)
+    version_label.pack(fill="x")
 
     return button, version_label
 
@@ -2222,13 +2232,7 @@ class VBS4Panel(tk.Frame):
             bg="black", fg="white", pady=20
         ).pack(fill="x")
 
-         # VBS4 Launch frame
-        vbs4_frame = tk.Frame(self, bg="#333333")
-        vbs4_frame.pack(pady=8)
-
-        vbs4_path = get_vbs4_install_path()
-        logging.debug("VBS4 path for button creation: %s", vbs4_path)
-
+        # VBS4 button + version
         self.vbs4_button, self.vbs4_version_label = create_app_button(
             self, "VBS4", get_vbs4_install_path, launch_vbs4,
             lambda: self.set_file_location("VBS4", "vbs4_path", self.vbs4_button)
@@ -2236,36 +2240,29 @@ class VBS4Panel(tk.Frame):
         self.update_vbs4_version()
         self.update_vbs4_button_state()
 
-        # VBS4 version label
-        self.vbs4_version_label = tk.Label(
-            vbs4_frame,
-            text="",
-            font=("Helvetica", 16),
-            bg="#333333", fg="white"
-        )
-        self.vbs4_version_label.pack(side=tk.LEFT, padx=10)
-        self.update_vbs4_version()
-
-        self.vbs4_launcher_button, _ = create_app_button(
-            self, "VBS4 Launcher", 
+        # VBS4 launcher (no version label displayed)
+        self.vbs4_launcher_button, launcher_label = create_app_button(
+            self, "VBS4 Launcher",
             lambda: config['General'].get('vbs4_setup_path', ''),
             launch_vbs4_setup,
             lambda: self.set_file_location("VBS4 Launcher", "vbs4_setup_path", self.vbs4_launcher_button)
         )
+        launcher_label.pack_forget()
         self.update_vbs4_launcher_button_state()
 
-        # BlueIG frame for dynamic buttons + version label handled below
+        # BlueIG frame for dynamic buttons and version label
         self.blueig_frame = tk.Frame(self, bg="#333333")
-        self.blueig_frame.pack(pady=8)
+        self.blueig_frame.pack(pady=8, fill="x")
         self.create_blueig_button()
 
-        # VBS License Manager button
-        self.vbs_license_button, _ = create_app_button(
-            self, "VBS License Manager", 
+        # VBS License Manager button (no version label)
+        self.vbs_license_button, license_label = create_app_button(
+            self, "VBS License Manager",
             lambda: config['General'].get('vbs_license_manager_path', ''),
             self.launch_vbs_license_manager,
             lambda: self.set_file_location("VBS License Manager", "vbs_license_manager_path", self.vbs_license_button)
         )
+        license_label.pack_forget()
 
         # Terrain Converter Section
         self.terrain_frame = tk.Frame(self, bg="#333333")
@@ -2374,23 +2371,14 @@ class VBS4Panel(tk.Frame):
             widget.destroy()
 
         is_srv = config['General'].getboolean('is_server', fallback=False)
-        state = 'disabled' if is_srv else 'normal'
 
         # Launch BlueIG button
         self.blueig_button, self.blueig_version_label = create_app_button(
-            self, "BlueIG", get_blueig_install_path, self.show_scenario_buttons,
+            self.blueig_frame, "BlueIG", get_blueig_install_path, self.show_scenario_buttons,
             lambda: self.set_file_location("BlueIG", "blueig_path", self.blueig_button)
         )
-        self.update_blueig_version()
-
-        # BlueIG version label (now here, after the button)
-        self.blueig_version_label = tk.Label(
-            self.blueig_frame,
-            text="",
-            font=('Helvetica', 16),
-            bg='#333333', fg='white'
-        )
-        self.blueig_version_label.pack(side=tk.LEFT, padx=10)
+        if is_srv:
+            self.blueig_button.config(state="disabled", bg="#888888")
         self.update_blueig_version()
 
     def update_vbs4_version(self):
@@ -3154,25 +3142,10 @@ class BVIPanel(tk.Frame):
                  bg='black', fg='white', pady=20) \
           .pack(fill='x')
 
-        bvi_frame = tk.Frame(self, bg="#333333")
-        bvi_frame.pack(pady=8)
-
         self.bvi_button, self.bvi_version_label = create_app_button(
             self, "BVI", get_ares_manager_path, launch_bvi,
             lambda: self.set_file_location("BVI", "bvi_manager_path", self.bvi_button)
         )
-        self.update_bvi_version()
-
-        # BVI Version label
-        self.bvi_version_label = tk.Label(
-            bvi_frame,
-            text="",
-            font=("Helvetica", 16),
-            bg="#333333", fg="white"
-        )
-        self.bvi_version_label.pack(side=tk.LEFT, padx=10)
-
-        # Update BVI version label
         self.update_bvi_version()
 
         tk.Button(self, text="Open Terrain",


### PR DESCRIPTION
## Summary
- Stack launch buttons and version labels vertically so each fills the panel width
- Update VBS4 panel to use shared button creator for consistent sizing
- Simplify BVI panel layout using the same helper

## Testing
- `python -m py_compile PythonPorjects/STE_Toolkit.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a47d48ffd8832286584d89afc4165c

## Summary by Sourcery

Standardize and simplify application launch panels by introducing a shared button creator and refactoring VBS4, BlueIG, and BVI layouts to use it for uniform sizing and layout.

Enhancements:
- Introduce a shared create_app_button helper that stacks launch buttons and version labels vertically, fills the parent width, and provides consistent sizing
- Refactor VBS4 panel to use create_app_button for both main and setup launchers, hiding unused version labels
- Update BlueIG panel to use create_app_button, remove manual layout code, and disable the button when running as a server
- Simplify BVI panel layout by migrating to create_app_button and eliminating redundant frame and label creation