### PR TITLE
style: darken BlueIG frame

### DIFF
--- a/PythonPorjects/STE_Toolkit.py
+++ b/PythonPorjects/STE_Toolkit.py
@@ -2081,7 +2081,14 @@ class MainMenu(tk.Frame):
         ).pack(fill="x")
 
         # BlueIG Frame (dynamic)
-        self.blueig_frame = tk.Frame(self, bg=self.cget("bg"), bd=0, highlightthickness=0)
+        # Use a darker gray background so the surrounding area of the
+        # collapsible buttons is not the default light/white color.
+        self.blueig_frame = tk.Frame(
+            self,
+            bg="#333333",
+            bd=0,
+            highlightthickness=0,
+        )
         self.blueig_frame.pack(pady=10)
         self.create_blueig_button()
 
@@ -2162,8 +2169,12 @@ class MainMenu(tk.Frame):
                 self.blueig_frame,
                 text=f"Launch BlueIG HammerKit 1-{i}",
                 font=("Helvetica", 20),
-                bg="#444444", fg="white",
-                width=30, height=1,
+                bg="#444444",
+                fg="white",
+                width=30,
+                height=1,
+                bd=0,
+                highlightthickness=0,
                 command=lambda n=i: self.launch_blueig_scenario(n)
             ).pack(pady=5)
 
@@ -2171,8 +2182,11 @@ class MainMenu(tk.Frame):
             self.blueig_frame,
             text="Back",
             font=("Helvetica", 18),
-            bg="#666666", fg="white",
+            bg="#666666",
+            fg="white",
             width=10,
+            bd=0,
+            highlightthickness=0,
             command=self.create_blueig_button
         ).pack(pady=10)
 
@@ -2246,7 +2260,12 @@ class VBS4Panel(tk.Frame):
         )
         self.update_vbs4_launcher_button_state()
 
-        self.blueig_frame = tk.Frame(self, bg=self.cget("bg"), bd=0, highlightthickness=0)
+        self.blueig_frame = tk.Frame(
+            self,
+            bg="#333333",
+            bd=0,
+            highlightthickness=0,
+        )
         self.blueig_frame.pack(pady=10)
         self.create_blueig_button()
 
@@ -2274,8 +2293,7 @@ class VBS4Panel(tk.Frame):
         )
         self.terrain_button.bind("<Leave>", self.hide_tooltip)
 
-        self.terrain_frame = tk.Frame(self, bg=self.cget("bg"), bd=0, highlightthickness=0)
-        self.terrain_frame.pack()
+        self.terrain_frame = tk.Frame(self, bg="#333333", bd=0, highlightthickness=0)
         self.create_hidden_terrain_buttons()
         self.update_fuser_state()
 
@@ -2446,6 +2464,8 @@ class VBS4Panel(tk.Frame):
                 fg="white",
                 width=30,
                 height=1,
+                bd=0,
+                highlightthickness=0,
                 command=lambda n=i: self.launch_blueig_scenario(n),
             ).pack(pady=10)
 
@@ -2457,6 +2477,8 @@ class VBS4Panel(tk.Frame):
             fg="white",
             width=30,
             height=1,
+            bd=0,
+            highlightthickness=0,
             command=self.create_blueig_button,
         ).pack(pady=10)
 
@@ -2596,12 +2618,14 @@ class VBS4Panel(tk.Frame):
     def toggle_terrain_buttons(self):
         if self.terrain_button.cget("text") == "One-Click Terrain Converter":
             self.terrain_button.config(text="Hide Terrain Options")
+            self.terrain_frame.pack()
             for button in self.hidden_buttons:
                 button.pack(pady=10)
         else:
             self.terrain_button.config(text="One-Click Terrain Converter")
             for button in self.hidden_buttons:
                 button.pack_forget()
+            self.terrain_frame.pack_forget()
 
     def update_vbs4_button_state(self):
         path = get_vbs4_install_path()


### PR DESCRIPTION
## Summary
- use dark gray background for BlueIG scenario frame in main menu and VBS4 panel
- remove default borders on BlueIG scenario buttons for a cleaner look
- apply dark gray frame to One-Click Terrain Converter and collapse frame when hidden

## Testing
- `python -m py_compile PythonPorjects/STE_Toolkit.py`


------
https://chatgpt.com/codex/tasks/task_e_68a4b83d6dd4832295d9419f833719f3

## Summary by Sourcery

Update UI styles by applying a dark gray background to BlueIG and terrain frames, remove button borders for a cleaner look, and collapse the terrain options frame when hidden.

Enhancements:
- Apply a dark gray (#333333) background to BlueIG frames in both the main menu and VBS4 panel
- Replace default frame background for the One-Click Terrain Converter with the same dark gray and collapse its frame when hidden
- Remove borders and highlight thickness from BlueIG scenario buttons and navigation controls for a sleeker interface