### PR TITLE
Use VBS4 version for launcher label

### DIFF
--- a/PythonPorjects/STE_Toolkit.py
+++ b/PythonPorjects/STE_Toolkit.py
@@ -2250,15 +2250,16 @@ class VBS4Panel(tk.Frame):
             self, "VBS4", get_vbs4_install_path, launch_vbs4,
             lambda: self.set_file_location("VBS4", "vbs4_path", self.vbs4_button)
         )
-        self.update_vbs4_version()
-        self.update_vbs4_button_state()
 
-        self.vbs4_launcher_button, _ = create_app_button(
+        self.vbs4_launcher_button, self.vbs4_launcher_version_label = create_app_button(
             self, "VBS4 Launcher",
             lambda: config['General'].get('vbs4_setup_path', ''),
             launch_vbs4_setup,
             lambda: self.set_file_location("VBS4 Launcher", "vbs4_setup_path", self.vbs4_launcher_button)
         )
+
+        self.update_vbs4_version()
+        self.update_vbs4_button_state()
         self.update_vbs4_launcher_button_state()
 
         self.blueig_frame = tk.Frame(
@@ -2438,6 +2439,9 @@ class VBS4Panel(tk.Frame):
         path = get_vbs4_install_path()
         ver = get_vbs4_version(path)
         self.vbs4_version_label.config(text=f"Version: {ver}")
+        # The VBS4 Launcher shares the same version as VBS4 itself
+        if hasattr(self, 'vbs4_launcher_version_label'):
+            self.vbs4_launcher_version_label.config(text=f"Version: {ver}")
 
     def update_blueig_version(self):
         path = get_blueig_install_path()


### PR DESCRIPTION
## Summary
- Display VBS4 launcher version using the same version as VBS4
- Update VBS4 version helper to set launcher version label

## Testing
- `python -m py_compile PythonPorjects/STE_Toolkit.py`


------
https://chatgpt.com/codex/tasks/task_e_68a5cd4aa5188322852fc711c7db71a7

## Summary by Sourcery

Add a version label to the VBS4 Launcher button mirroring the main VBS4 version and adjust initialization order to ensure proper label updates.

New Features:
- Add version label to VBS4 Launcher button reflecting the VBS4 installation version

Enhancements:
- Reorder VBS4 version and button state update calls to run after launcher button creation