### PR TITLE
feat: add host-aware UNC path templating

### DIFF
--- a/PythonPorjects/config.ini
+++ b/PythonPorjects/config.ini
@@ -1,6 +1,6 @@
 [General]
 close_on_launch = False
-reality_mesh_to_vbs4 = \\HAMMERKIT1-4\SharedMeshDrive\ReailityMeshInstall\Reality Mesh to VBS4.lnk
+reality_mesh_to_vbs4 = \\{host}\SharedMeshDrive\RealityMeshInstall\Reality Mesh to VBS4.lnk
 default_browser = C:/Users/tifte/AppData/Local/Programs/Opera GX/opera.exe
 vbs4_path = C:\Builds\VBS4\VBS4 YYMEA_General\VBS4.exe
 blueig_path = C:\Builds\BlueIG\Blue IG 24.2 YYMEA_General\BlueIG.exe

--- a/PythonPorjects/distribution_paths.json
+++ b/PythonPorjects/distribution_paths.json
@@ -1,5 +1,5 @@
 {
     "paths": [
-        "\\\\HAMMERKIT1-4\\SharedMeshDrive\\VBS4_XYZ"
+        "\\\\{host}\\SharedMeshDrive\\VBS4_XYZ"
     ]
 }

--- a/PythonPorjects/fuser_config.json
+++ b/PythonPorjects/fuser_config.json
@@ -1,5 +1,5 @@
 {
-  "shared_path": "\\\\HAMMERKIT1-4\\SharedMeshDrive\\WorkingFuser",
+  "shared_path": "\\\\{host}\\SharedMeshDrive\\WorkingFuser",
   "fusers": {
     "localhost": [
       {

--- a/PythonPorjects/photomesh/Invoke-RemoteRealityMesh.ps1
+++ b/PythonPorjects/photomesh/Invoke-RemoteRealityMesh.ps1
@@ -16,7 +16,7 @@ $RemoteBatchRoot = "C:\Users\tifte\Documents\GitHub\VBS4Project\PythonPorjects\p
 $RemoteBatchFile = "RealityMeshProcess.bat"
 
 # Shared roots for inputs and outputs
-$sharedRoot = '\\HAMMERKIT1-4\SharedMeshDrive\RealityMesh'
+$sharedRoot = '\\{host}\SharedMeshDrive\RealityMesh'
 $inputRoot  = Join-Path $sharedRoot 'Input'
 $outputRoot = Join-Path $sharedRoot 'Output'
 

--- a/PythonPorjects/photomesh/RealityMeshProcess.ps1
+++ b/PythonPorjects/photomesh/RealityMeshProcess.ps1
@@ -109,7 +109,7 @@ $RemoteBatchFile = "RealityMeshProcess.bat"                                     
 
 # ---------- Shared roots (MUST include server name) ----------
 # Base shared drive accessible by both the calling and remote machines
-$sharedRoot = '\\HAMMERKIT1-4\SharedMeshDrive\RealityMesh'
+$sharedRoot = '\\{host}\SharedMeshDrive\RealityMesh'
 $inputRoot  = Join-Path $sharedRoot 'Input'
 $outputRoot = Join-Path $sharedRoot 'Output'
 

--- a/PythonPorjects/photomesh/RealityMeshRunner.ps1
+++ b/PythonPorjects/photomesh/RealityMeshRunner.ps1
@@ -41,7 +41,7 @@ $RemoteBatchFile = "RealityMeshProcess.bat"
 [bool]$UseTclDirect = $false   # set $true only if you want the old TCL path
 
 # ---- Shared roots (UNC) ----
-$sharedRoot = '\\HAMMERKIT1-4\SharedMeshDrive\RealityMesh'
+$sharedRoot = '\\{host}\SharedMeshDrive\RealityMesh'
 $inputRoot  = Join-Path $sharedRoot 'Input'
 $outputRoot = Join-Path $sharedRoot 'Output'
 Ensure-Directory $sharedRoot; Ensure-Directory $inputRoot; Ensure-Directory $outputRoot

--- a/PythonPorjects/photomesh/RealityMeshSystemSettings.txt
+++ b/PythonPorjects/photomesh/RealityMeshSystemSettings.txt
@@ -11,4 +11,4 @@ terratools_home_path=C:\Program Files\Bohemia Interactive Simulations\TerraTools
 dataset_root=C:\BiSim OneClick\Datasets
 export_format=OBJ
 center_pivot_to_project=true
-reality_mesh_to_vbs4_path=\\HAMMERKIT1-4\SharedMeshDrive\ReailityMeshInstall\Reality Mesh to VBS4.lnk
+reality_mesh_to_vbs4_path=\\{host}\SharedMeshDrive\RealityMeshInstall\Reality Mesh to VBS4.lnk

--- a/RealityMeshSystemSettings.txt
+++ b/RealityMeshSystemSettings.txt
@@ -12,4 +12,4 @@ terratools_home_path=C:\Program Files\Bohemia Interactive Simulations\TerraTools
 dataset_root=C:\BiSim OneClick\Datasets
 export_format=OBJ
 center_pivot_to_project=true
-reality_mesh_to_vbs4_path=\\HAMMERKIT1-4\SharedMeshDrive\ReailityMeshInstall\Reality Mesh to VBS4.lnk
+reality_mesh_to_vbs4_path=\\{host}\SharedMeshDrive\RealityMeshInstall\Reality Mesh to VBS4.lnk


### PR DESCRIPTION
## Summary
- support configurable network hosts via template helpers
- show and save host name in settings, updating one-click paths in real time
- resolve UNC templates for Reality Mesh shortcut with search and diagnostics
- fix template migration to preserve valid UNC paths when upgrading configs
- skip UNC host existence check when diagnosing missing path segments

## Testing
- `python -m py_compile PythonPorjects/STE_Toolkit.py`


------
https://chatgpt.com/codex/tasks/task_e_68a73d05f35083229d2112359dbd81c8

## Summary by Sourcery

Support dynamic network hosts in UNC path resolution by introducing a {host} template token, adding persistent host settings with UI controls, migrating existing configurations, and enhancing Reality Mesh shortcut discovery and diagnostics

New Features:
- Introduce templated UNC paths using a {host} placeholder for Reality Mesh shortcuts and shared mesh directories
- Add settings UI to view and configure the network host with real-time updates to one-click and Reality Mesh link paths
- Implement migration logic to convert existing static UNC paths to the new {host}-templated format

Bug Fixes:
- Preserve valid UNC paths during template migration when upgrading configurations
- Skip existence check for the initial UNC host segment in diagnostics to prevent false missing-segment errors

Enhancements:
- Provide detailed diagnostics for missing UNC path segments and safe directory listings when shortcuts cannot be found
- Automatically search under the configured host share for Reality Mesh shortcut if the templated path is missing