### PR TITLE
Ensure One-Click uses PhotoMesh Wizard defaults

### DIFF
--- a/PythonPorjects/STE_Toolkit.py
+++ b/PythonPorjects/STE_Toolkit.py
@@ -19,7 +19,12 @@ import socket
 import threading
 import shlex
 from post_process_utils import clean_project_settings
-from launch_photomesh_preset import launch_photomesh_with_preset
+from launch_photomesh_preset import (
+    ensure_wizard_user_defaults,
+    ensure_wizard_install_defaults,
+    launch_wizard_cli,
+    DEFAULT_WIZARD_PRESET,
+)
 from collections import OrderedDict
 import time
 import glob
@@ -3063,8 +3068,13 @@ class VBS4Panel(tk.Frame):
                 self.log_message(f"Failed to start {name}: {e}")
 
     def create_mesh(self):
+        # Ensure OBJ export is enabled even if install config fails to update
         enable_obj_in_photomesh_config()
-        set_active_wizard_preset()
+
+        # Apply Wizard defaults so the correct preset is auto-loaded and
+        # the build runs using the shared network working folder.
+        ensure_wizard_user_defaults(DEFAULT_WIZARD_PRESET, autostart=True)
+        ensure_wizard_install_defaults()
         if not hasattr(self, 'image_folder_paths') or not self.image_folder_paths:
             self.select_imagery()
             if not hasattr(self, 'image_folder_paths') or not self.image_folder_paths:
@@ -3086,7 +3096,7 @@ class VBS4Panel(tk.Frame):
         self.log_message(f"Creating mesh for project: {project_name}")
 
         try:
-            launch_photomesh_with_preset(project_name, project_path, self.image_folder_paths)
+            launch_wizard_cli(project_name, project_path, self.image_folder_paths)
             self.log_message("PhotoMesh Wizard launched successfully.")
             messagebox.showinfo(
                 "PhotoMesh Wizard Launched",

--- a/PythonPorjects/launch_photomesh_preset.py
+++ b/PythonPorjects/launch_photomesh_preset.py
@@ -2,12 +2,42 @@ from pathlib import Path
 import os
 import json
 import subprocess
-from typing import Iterable
+import configparser
+from typing import Iterable, List
 
-# Constants
-PRESET_NAME = "CPP&OBJ"
-WIZARD_EXE = r"C:\Program Files\Skyline\PhotoMeshWizard\PhotoMeshWizard.exe"
-PHOTOMESH_CONFIG = r"C:\Program Files\Skyline\PhotoMesh\Tools\PhotomeshWizard\config.json"
+# ---------------------------------------------------------------------------
+# PhotoMesh Wizard configuration
+# ---------------------------------------------------------------------------
+
+# User-level config written under %APPDATA%
+WIZARD_USER_CFG = os.path.join(
+    os.environ.get("APPDATA", ""), "Skyline", "PhotoMesh", "Wizard", "config.json"
+)
+
+# Installed Wizard config (official path per manual)
+WIZARD_INSTALL_CFG = (
+    r"C:\Program Files\Skyline\PhotoMesh\Tools\PhotomeshWizard\config.json"
+)
+
+# PhotoMesh Wizard executable
+WIZARD_EXE = (
+    r"C:\Program Files\Skyline\PhotoMesh\Tools\PhotomeshWizard\WizardGUI.exe"
+)
+
+# Load shared configuration for network fuser settings
+BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+CONFIG_PATH = os.path.join(BASE_DIR, "config.ini")
+_cfg = configparser.ConfigParser()
+_cfg.read(CONFIG_PATH)
+
+WORKING_FOLDER_HOST = _cfg.get("Fusers", "working_folder_host", fallback="HAMMERKIT1-4")
+NETWORK_WORKING_FOLDER = fr"\\{WORKING_FOLDER_HOST}\SharedMeshDrive\FuserWorking"
+
+# Default preset name used by Wizard
+DEFAULT_WIZARD_PRESET = "CPP&OBJ"
+
+# Legacy constant kept for compatibility with existing helpers
+PRESET_NAME = DEFAULT_WIZARD_PRESET
 
 PRESET_XML = """<?xml version="1.0" encoding="utf-8"?>
 <BuildParametersPreset xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
@@ -54,6 +84,79 @@ PRESET_XML = """<?xml version="1.0" encoding="utf-8"?>
   <PresetName>CPP&amp;OBJ</PresetName>
 </BuildParametersPreset>
 """
+
+
+def ensure_wizard_user_defaults(
+    preset: str = DEFAULT_WIZARD_PRESET, autostart: bool = True
+) -> None:
+    """Ensure the PhotoMesh Wizard user config selects *preset* and auto-builds."""
+
+    os.makedirs(os.path.dirname(WIZARD_USER_CFG), exist_ok=True)
+    cfg = {
+        "SelectedPreset": preset,
+        "OverrideSettings": True,
+        "AutoBuild": bool(autostart),
+    }
+    with open(WIZARD_USER_CFG, "w", encoding="utf-8") as f:
+        json.dump(cfg, f, indent=2)
+
+
+def ensure_wizard_install_defaults() -> None:
+    """Patch the installed Wizard config for OBJ export and network settings."""
+
+    path = WIZARD_INSTALL_CFG
+    if not os.path.isfile(path):
+        return
+
+    with open(path, "r", encoding="utf-8") as f:
+        try:
+            cfg = json.load(f)
+        except Exception:
+            cfg = {}
+
+    cfg.setdefault("UseMinimize", True)
+    cfg.setdefault("ClosePMWhenDone", False)
+    cfg.setdefault("OutputWaitTimerSeconds", 10)
+
+    cfg["NetworkWorkingFolder"] = NETWORK_WORKING_FOLDER
+
+    ui = cfg.setdefault("DefaultPhotoMeshWizardUI", {})
+    formats = ui.setdefault("Model3DFormats", {})
+    formats["OBJ"] = True
+    formats["3DML"] = False
+
+    ui.setdefault("ProcessingLevel", "Standard")
+    ui.setdefault("StopOnError", True)
+    ui.setdefault("MaxProcessing", False)
+
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(cfg, f, indent=2)
+
+
+def launch_wizard_cli(project_name: str, project_path: str, folders: List[str]) -> None:
+    """Launch the PhotoMesh Wizard with prepared sources via CLI."""
+
+    if not os.path.isfile(WIZARD_EXE):
+        from tkinter import messagebox
+
+        messagebox.showerror(
+            "PhotoMesh Wizard", "WizardGUI.exe not found.\nCheck installation path."
+        )
+        return
+
+    args = [WIZARD_EXE, "--projectName", project_name, "--projectPath", project_path]
+    for fld in folders:
+        args += ["--folder", fld]
+
+    ensure_wizard_user_defaults(DEFAULT_WIZARD_PRESET, autostart=True)
+    ensure_wizard_install_defaults()
+
+    try:
+        subprocess.Popen(args, cwd=os.path.dirname(WIZARD_EXE))
+    except Exception as e:
+        from tkinter import messagebox
+
+        messagebox.showerror("PhotoMesh Wizard", f"Failed to launch Wizard:\n{e}")
 
 def ensure_preset_exists() -> str:
     """Write the CPP&OBJ preset file and return its path."""


### PR DESCRIPTION
## Summary
- add helpers to configure PhotoMesh Wizard user/install defaults and launch via CLI
- wire One-Click mesh creation to use new helpers and shared network working folder

## Testing
- `python -m py_compile PythonPorjects/launch_photomesh_preset.py PythonPorjects/STE_Toolkit.py`


------
https://chatgpt.com/codex/tasks/task_e_68a877a5dd908322805232ae0358315a

## Summary by Sourcery

Ensure One-Click mesh creation uses PhotoMesh Wizard defaults by introducing configuration helpers for user/install settings and a CLI launcher, and update STE_Toolkit to apply these settings and shared network working folder.

New Features:
- Add helpers to configure PhotoMesh Wizard user and install defaults
- Introduce launch_wizard_cli function to start the Wizard via CLI

Enhancements:
- Load shared network working folder from config.ini and update script constants
- Wire STE_Toolkit create_mesh to use new helpers, enable OBJ export, and launch via launch_wizard_cli