### PR TITLE
Ensure One-Click uses PhotoMesh Wizard defaults

### DIFF
--- a/PythonPorjects/STE_Toolkit.py
+++ b/PythonPorjects/STE_Toolkit.py
@@ -19,7 +19,12 @@ import socket
 import threading
 import shlex
 from post_process_utils import clean_project_settings
-from launch_photomesh_preset import launch_photomesh_with_preset
+from launch_photomesh_preset import (
+    ensure_wizard_user_defaults,
+    ensure_wizard_install_defaults,
+    launch_wizard_cli,
+    DEFAULT_WIZARD_PRESET,
+)
 from collections import OrderedDict
 import time
 import glob
@@ -3063,8 +3068,13 @@ class VBS4Panel(tk.Frame):
                 self.log_message(f"Failed to start {name}: {e}")
 
     def create_mesh(self):
+        # Ensure OBJ export is enabled even if install config fails to update
         enable_obj_in_photomesh_config()
-        set_active_wizard_preset()
+
+        # Apply Wizard defaults so the correct preset is auto-loaded and
+        # the build runs using the shared network working folder.
+        ensure_wizard_user_defaults(DEFAULT_WIZARD_PRESET, autostart=True)
+        ensure_wizard_install_defaults()
         if not hasattr(self, 'image_folder_paths') or not self.image_folder_paths:
             self.select_imagery()
             if not hasattr(self, 'image_folder_paths') or not self.image_folder_paths:
@@ -3086,7 +3096,7 @@ class VBS4Panel(tk.Frame):
         self.log_message(f"Creating mesh for project: {project_name}")
 
         try:
-            launch_photomesh_with_preset(project_name, project_path, self.image_folder_paths)
+            launch_wizard_cli(project_name, project_path, self.image_folder_paths)
             self.log_message("PhotoMesh Wizard launched successfully.")
             messagebox.showinfo(
                 "PhotoMesh Wizard Launched",


### PR DESCRIPTION
## Summary
- add helpers to configure PhotoMesh Wizard user/install defaults and launch via CLI
- wire One-Click mesh creation to use new helpers and shared network working folder
- fix PhotoMesh Wizard path to use `C:\\Program Files\\Skyline\\PhotoMeshWizard\\PhotoMeshWizard.exe`

## Testing
- `python -m py_compile PythonPorjects/launch_photomesh_preset.py PythonPorjects/STE_Toolkit.py`


------
https://chatgpt.com/codex/tasks/task_e_68a877a5dd908322805232ae0358315a

## Summary by Sourcery

Configure PhotoMesh Wizard with user/install defaults and shared network settings, fix executable path, and integrate the new launch helper into the One-Click mesh creation workflow

New Features:
- Introduce ensure_wizard_user_defaults to configure user presets and auto-build settings
- Introduce ensure_wizard_install_defaults to patch installed Wizard config for OBJ export and shared network folder
- Add launch_wizard_cli helper to invoke PhotoMesh Wizard via CLI with prepared defaults

Bug Fixes:
- Correct PhotoMeshWizard.exe installation path

Enhancements:
- Load network working folder from config.ini and apply it in install defaults
- Update One-Click mesh creation in STE_Toolkit to use new Wizard defaults and CLI launcher