### PR TITLE
Improve Reality Mesh UNC path handling

### DIFF
--- a/PythonPorjects/config.ini
+++ b/PythonPorjects/config.ini
@@ -1,6 +1,6 @@
 [General]
 close_on_launch = False
-reality_mesh_to_vbs4 = \\HAMMERKIT1-4\SharedMeshDrive\ReailityMeshInstall\Reality Mesh to VBS4.lnk
+reality_mesh_to_vbs4 = \\{host}\SharedMeshDrive\RealityMeshInstall\Reality Mesh to VBS4.lnk
 default_browser = C:/Users/tifte/AppData/Local/Programs/Opera GX/opera.exe
 vbs4_path = C:\Builds\VBS4\VBS4 YYMEA_General\VBS4.exe
 blueig_path = C:\Builds\BlueIG\Blue IG 24.2 YYMEA_General\BlueIG.exe


### PR DESCRIPTION
## Summary
- Add host-aware Reality Mesh shortcut template with config migration and support for both `RealityMeshInstall` and `ReailityMeshInstall` share names
- Implement flexible UNC resolution utilities and enhanced diagnostics that report the first missing path segment
- Launch Reality Mesh to VBS4 using the tolerant search and show the resolved shortcut path in the VBS4 panel

## Testing
- `python -m py_compile PythonPorjects/STE_Toolkit.py`


------
https://chatgpt.com/codex/tasks/task_e_68a87e1d8ea48322ad1ac41b0fdf1679