### PR TITLE
feat: prefer local Reality Mesh install

### DIFF
--- a/PythonPorjects/config.ini
+++ b/PythonPorjects/config.ini
@@ -1,6 +1,7 @@
 [General]
 close_on_launch = False
 reality_mesh_to_vbs4 = \\{host}\SharedMeshDrive\RealityMeshInstall\Reality Mesh to VBS4.lnk
+reality_mesh_local_root = D:\RealityMeshInstall
 default_browser = C:/Users/tifte/AppData/Local/Programs/Opera GX/opera.exe
 vbs4_path = C:\Builds\VBS4\VBS4 YYMEA_General\VBS4.exe
 blueig_path = C:\Builds\BlueIG\Blue IG 24.2 YYMEA_General\BlueIG.exe


### PR DESCRIPTION
## Summary
- prioritize local Reality Mesh install and verify drive matches dataset
- expose Reality Mesh Local Root setting with browse/save controls
- show active RM link source on VBS4 panel and block mismatched drives

## Testing
- `python -m py_compile STE_Toolkit.py`
- `python -m py_compile reality_mesh_gui.py`


------
https://chatgpt.com/codex/tasks/task_e_68ac62838aa48322bbc3529f782dc9d4

## Summary by Sourcery

Enable preference of local Reality Mesh installation over UNC shares with UI controls, drive validation, and status reporting in the VBS4 panel.

New Features:
- Expose a 'Reality Mesh Local Root' setting with browse and save controls in the settings panel
- Prefer launching the local Reality Mesh shortcut when on the same drive, falling back to UNC
- Block launch and prompt user when the local root and dataset drives mismatch
- Display the active Reality Mesh link source (LOCAL, UNC, or DIFFERENT_DRIVE) in the VBS4 panel status

Enhancements:
- Refactor reality mesh shortcut lookup into find_unc_rm_link, find_local_rm_link, and resolve_active_rm_link helpers
- Improve error messages and status updates for missing or failed Reality Mesh launches

Documentation:
- Add default reality_mesh_local_root entry to config.ini