### PR TITLE
feat: add sentinel-based Reality Mesh launcher

### DIFF
--- a/PythonPorjects/config.ini
+++ b/PythonPorjects/config.ini
@@ -1,6 +1,6 @@
 [General]
 close_on_launch = False
-reality_mesh_local_root = D:\SharedMeshDrive\RealityMeshInstall
+reality_mesh_local_root = D:\SharedMeshDrive
 default_browser = C:/Users/tifte/AppData/Local/Programs/Opera GX/opera.exe
 vbs4_path = C:\Builds\VBS4\VBS4 YYMEA_General\VBS4.exe
 blueig_path = C:\Builds\BlueIG\Blue IG 24.2 YYMEA_General\BlueIG.exe


### PR DESCRIPTION
## Summary
- validate Reality Mesh local root with Datatarget.txt sentinel
- search for RM shortcut with flexible path handling and drive checks
- enhance settings panel and status updates for local vs UNC launch

## Testing
- `python -m py_compile PythonPorjects/STE_Toolkit.py`

------
https://chatgpt.com/codex/tasks/task_e_68ac723aaeb483228298520f71f0478a

## Summary by Sourcery

Add sentinel-based validation and robust launcher for Reality Mesh with enhanced diagnostics and UI feedback

New Features:
- Validate and enforce that the local Reality Mesh root contains Datatarget.txt before saving settings or launching
- Attempt local launch by locating the shortcut under predefined subdirectories and enforce same-drive requirement with the dataset
- Fallback to UNC launch with detailed diagnostics and optional directory listings on failure

Enhancements:
- Introduce utilities for safe directory listing, UNC path diagnostics, and drive-letter extraction
- Update settings panel and status labels to reflect validation errors, drive mismatches, and active launch source

Chores:
- Update default reality_mesh_local_root in config.ini to the drive root instead of nested install folder