### PR TITLE
Add offline LAN coordination mode

### DIFF
--- a/PythonPorjects/config.ini
+++ b/PythonPorjects/config.ini
@@ -27,3 +27,12 @@ working_folder_host = Kit1-1
 [BiSimOneClickPath]
 path = C:\BiSim OneClick\Datasets\CACTF_BUILD_20250814_134554
 
+[Offline]
+enabled = False
+host_name = KIT-HOST
+host_ip = 192.168.50.10
+share_name = SharedMeshDrive
+local_data_root = D:\SharedMeshDrive
+working_fuser_subdir = WorkingFuser
+use_ip_unc = False
+


### PR DESCRIPTION
## Summary
- introduce Offline settings to coordinate PhotoMesh builds over a shared SMB folder
- route Wizard and fuser configs through resolve_network_working_folder and gate fusers when offline
- add Offline Mode settings UI with live UNC preview, test access, and host share bootstrap

## Testing
- `python -m py_compile PythonPorjects/launch_photomesh_preset.py PythonPorjects/STE_Toolkit.py`


------
https://chatgpt.com/codex/tasks/task_e_68af11a012a88322855f2b64b6c83238

## Summary by Sourcery

Introduce an offline LAN coordination mode by adding configuration, access checking, UI controls, and share bootstrap support for coordinating PhotoMesh builds over a shared SMB folder.

New Features:
- Add Offline Mode UI with settings for host name, IP, share name, local root, subdirectory, and UNC preview
- Introduce offline LAN coordination over a shared SMB folder via network working folder resolution and access checks
- Provide PowerShell-based host share bootstrap to automatically create and configure offline SMB share

Enhancements:
- Route Wizard and Fuser network folder settings through resolve_network_working_folder to respect offline mode
- Block Fuser and Wizard launches when offline mode is enabled and SMB share is unreachable
- Apply offline configuration changes automatically by hooking into settings enforcement routines