### PR TITLE
feat: add offline settings UI and share propagation

### DIFF
--- a/PythonPorjects/STE_Toolkit.py
+++ b/PythonPorjects/STE_Toolkit.py
@@ -28,12 +28,14 @@ from launch_photomesh_preset import (
     launch_wizard_cli,
     DEFAULT_WIZARD_PRESET,
     get_offline_cfg,
-    working_fuser_unc,
     resolve_network_working_folder,
+    resolve_network_working_folder_from_cfg,
     ensure_offline_share_exists,
     can_access_unc,
     OFFLINE_ACCESS_HINT,
     enforce_photomesh_settings,
+    open_in_explorer,
+    propagate_share_rename_in_config,
 )
 from collections import OrderedDict
 import time
@@ -3894,170 +3896,53 @@ class SettingsPanel(tk.Frame):
             fg="white",
             bd=0,
         ).pack(side="left", padx=8)
+        # ── Offline / Shared Drive group ─────────────────────────────
+        grp = tk.LabelFrame(self, text="Offline / Shared Drive", fg="white",
+                            bg=self.cget("bg"), labelanchor="nw", padx=10, pady=10)
+        grp.grid(row=3, column=0, sticky="ew", padx=10, pady=10)
 
-        # --- Offline Mode -----------------------------------------------
-        off_cfg = get_offline_cfg()
-        offline = tk.LabelFrame(
-            self, text="Offline Mode", bg="black", fg="white", font=("Helvetica", 16)
-        )
-        offline.grid(row=3, column=0, sticky="ew", padx=10, pady=(0, 6))
+        off = get_offline_cfg()
+        self.off_enabled      = tk.BooleanVar(value=off["enabled"])
+        self.off_host_name    = tk.StringVar(value=off["host_name"])
+        self.off_host_ip      = tk.StringVar(value=off["host_ip"])
+        self.off_share_name   = tk.StringVar(value=off["share_name"])
+        self.off_local_root   = tk.StringVar(value=off["local_data_root"])
+        self.off_work_subdir  = tk.StringVar(value=off["working_fuser_subdir"])
+        self.off_use_ip_unc   = tk.BooleanVar(value=off["use_ip_unc"])
 
-        self.offline_enabled_var = tk.BooleanVar(value=off_cfg["enabled"])
-        tk.Checkbutton(
-            offline,
-            text="Enable Offline Mode",
-            variable=self.offline_enabled_var,
-            font=("Helvetica", 16),
-            bg="#444444",
-            fg="white",
-            selectcolor="#444444",
-            command=self._refresh_offline_resolved,
-        ).pack(anchor="w", pady=2)
+        row0 = tk.Frame(grp, bg=self.cget("bg")); row0.pack(fill="x", pady=4)
+        tk.Checkbutton(row0, text="Enable Offline Mode", variable=self.off_enabled,
+                       bg=self.cget("bg"), fg="white", selectcolor=self.cget("bg")).pack(side="left")
+        tk.Checkbutton(row0, text="Use IP in UNC", variable=self.off_use_ip_unc,
+                       bg=self.cget("bg"), fg="white", selectcolor=self.cget("bg")).pack(side="left", padx=10)
 
-        row = tk.Frame(offline, bg="black")
-        tk.Label(row, text="Host Name:", font=("Helvetica", 14), bg="black", fg="white").pack(
-            side="left"
-        )
-        self.offline_host_name_var = tk.StringVar(value=off_cfg["host_name"])
-        tk.Entry(
-            row,
-            textvariable=self.offline_host_name_var,
-            font=("Consolas", 12),
-            bg="#111111",
-            fg="white",
-            insertbackground="white",
-            width=30,
-            bd=0,
-        ).pack(side="left", fill="x", expand=True, padx=5)
-        row.pack(fill="x", pady=2)
+        row1 = tk.Frame(grp, bg=self.cget("bg")); row1.pack(fill="x", pady=4)
+        tk.Label(row1, text="Host Name:", bg=self.cget("bg"), fg="white").pack(side="left", padx=(0,6))
+        tk.Entry(row1, textvariable=self.off_host_name, width=22, bg="#111", fg="white", insertbackground="white").pack(side="left")
+        tk.Label(row1, text="Host IP:", bg=self.cget("bg"), fg="white").pack(side="left", padx=(12,6))
+        tk.Entry(row1, textvariable=self.off_host_ip, width=16, bg="#111", fg="white", insertbackground="white").pack(side="left")
 
-        row = tk.Frame(offline, bg="black")
-        tk.Label(row, text="Host IP:", font=("Helvetica", 14), bg="black", fg="white").pack(
-            side="left"
-        )
-        self.offline_host_ip_var = tk.StringVar(value=off_cfg["host_ip"])
-        tk.Entry(
-            row,
-            textvariable=self.offline_host_ip_var,
-            font=("Consolas", 12),
-            bg="#111111",
-            fg="white",
-            insertbackground="white",
-            width=30,
-            bd=0,
-        ).pack(side="left", fill="x", expand=True, padx=5)
-        row.pack(fill="x", pady=2)
+        row2 = tk.Frame(grp, bg=self.cget("bg")); row2.pack(fill="x", pady=4)
+        tk.Label(row2, text="Share Name:", bg=self.cget("bg"), fg="white").pack(side="left", padx=(0,6))
+        tk.Entry(row2, textvariable=self.off_share_name, width=24, bg="#111", fg="white", insertbackground="white").pack(side="left")
 
-        row = tk.Frame(offline, bg="black")
-        tk.Label(row, text="Share Name:", font=("Helvetica", 14), bg="black", fg="white").pack(
-            side="left"
-        )
-        self.offline_share_var = tk.StringVar(value=off_cfg["share_name"])
-        tk.Entry(
-            row,
-            textvariable=self.offline_share_var,
-            font=("Consolas", 12),
-            bg="#111111",
-            fg="white",
-            insertbackground="white",
-            width=30,
-            bd=0,
-        ).pack(side="left", fill="x", expand=True, padx=5)
-        row.pack(fill="x", pady=2)
+        row3 = tk.Frame(grp, bg=self.cget("bg")); row3.pack(fill="x", pady=4)
+        tk.Label(row3, text="Local Data Root:", bg=self.cget("bg"), fg="white").pack(side="left", padx=(0,6))
+        tk.Entry(row3, textvariable=self.off_local_root, width=50, bg="#111", fg="white", insertbackground="white").pack(side="left", fill="x", expand=True)
+        tk.Button(row3, text="Browse...", bg="#444", fg="white",
+                  command=self._browse_local_root).pack(side="left", padx=8)
 
-        row = tk.Frame(offline, bg="black")
-        tk.Label(
-            row, text="Local Data Root:", font=("Helvetica", 14), bg="black", fg="white"
-        ).pack(side="left")
-        self.offline_local_root_var = tk.StringVar(value=off_cfg["local_data_root"])
-        tk.Entry(
-            row,
-            textvariable=self.offline_local_root_var,
-            font=("Consolas", 12),
-            bg="#111111",
-            fg="white",
-            insertbackground="white",
-            width=30,
-            bd=0,
-        ).pack(side="left", fill="x", expand=True, padx=5)
-        row.pack(fill="x", pady=2)
+        row4 = tk.Frame(grp, bg=self.cget("bg")); row4.pack(fill="x", pady=4)
+        tk.Label(row4, text="Working Fuser Subdir:", bg=self.cget("bg"), fg="white").pack(side="left", padx=(0,6))
+        tk.Entry(row4, textvariable=self.off_work_subdir, width=28, bg="#111", fg="white", insertbackground="white").pack(side="left")
 
-        row = tk.Frame(offline, bg="black")
-        tk.Label(
-            row,
-            text="Working Fuser Subdir:",
-            font=("Helvetica", 14),
-            bg="black",
-            fg="white",
-        ).pack(side="left")
-        self.offline_working_var = tk.StringVar(
-            value=off_cfg["working_fuser_subdir"]
-        )
-        tk.Entry(
-            row,
-            textvariable=self.offline_working_var,
-            font=("Consolas", 12),
-            bg="#111111",
-            fg="white",
-            insertbackground="white",
-            width=30,
-            bd=0,
-        ).pack(side="left", fill="x", expand=True, padx=5)
-        row.pack(fill="x", pady=2)
-
-        self.offline_use_ip_var = tk.BooleanVar(value=off_cfg["use_ip_unc"])
-        tk.Checkbutton(
-            offline,
-            text="Use IP instead",
-            variable=self.offline_use_ip_var,
-            font=("Helvetica", 16),
-            bg="#444444",
-            fg="white",
-            selectcolor="#444444",
-            command=self._refresh_offline_resolved,
-        ).pack(anchor="w", pady=2)
-
-        self.offline_resolved_var = tk.StringVar()
-        tk.Label(
-            offline,
-            textvariable=self.offline_resolved_var,
-            font=("Helvetica", 12),
-            bg="black",
-            fg="white",
-        ).pack(anchor="w", pady=(4, 2))
-
-        btn_row = tk.Frame(offline, bg="black")
-        tk.Button(
-            btn_row,
-            text="Save + Apply",
-            command=self._save_offline_settings,
-            font=("Helvetica", 12),
-            bg="#444444",
-            fg="white",
-            bd=0,
-        ).pack(side="left", padx=4)
-        tk.Button(
-            btn_row,
-            text="Test Access",
-            command=self._test_offline_access,
-            font=("Helvetica", 12),
-            bg="#444444",
-            fg="white",
-            bd=0,
-        ).pack(side="left", padx=4)
-        btn_row.pack(anchor="w", pady=(4, 0))
-
-        for var in [
-            self.offline_enabled_var,
-            self.offline_host_name_var,
-            self.offline_host_ip_var,
-            self.offline_share_var,
-            self.offline_local_root_var,
-            self.offline_working_var,
-            self.offline_use_ip_var,
-        ]:
-            var.trace_add("write", lambda *args: self._refresh_offline_resolved())
-        self._refresh_offline_resolved()
+        row5 = tk.Frame(grp, bg=self.cget("bg")); row5.pack(fill="x", pady=6)
+        tk.Button(row5, text="Save", bg="#444", fg="white",
+                  command=self._save_offline_settings).pack(side="left")
+        tk.Button(row5, text="Test Access", bg="#444", fg="white",
+                  command=self._test_offline_access).pack(side="left", padx=8)
+        tk.Button(row5, text="Open Working Folder", bg="#444", fg="white",
+                  command=self._open_working_folder).pack(side="left")
 
         # Reality Mesh Local Root
         rm_row = tk.Frame(self, bg="black")
@@ -4181,39 +4066,62 @@ class SettingsPanel(tk.Frame):
             highlightthickness=0,
         ).grid(row=6, column=0, pady=10)
 
-    def _collect_offline_inputs(self) -> dict:
-        return {
-            "enabled": self.offline_enabled_var.get(),
-            "host_name": self.offline_host_name_var.get().strip(),
-            "host_ip": self.offline_host_ip_var.get().strip(),
-            "share_name": self.offline_share_var.get().strip(),
-            "local_data_root": os.path.normpath(self.offline_local_root_var.get().strip()),
-            "working_fuser_subdir": self.offline_working_var.get().strip(),
-            "use_ip_unc": self.offline_use_ip_var.get(),
-        }
 
-    def _refresh_offline_resolved(self, *args):
-        path = working_fuser_unc(self._collect_offline_inputs())
-        self.offline_resolved_var.set(f"Resolved Working Folder: {path}")
+    def _browse_local_root(self):
+        p = filedialog.askdirectory(title="Select Local Data Root", initialdir=self.off_local_root.get() or "C:\\")
+        if p:
+            self.off_local_root.set(os.path.normpath(p))
 
     def _save_offline_settings(self):
-        o = self._collect_offline_inputs()
-        if 'Offline' not in config:
-            config['Offline'] = {}
-        sect = config['Offline']
-        for k, v in o.items():
-            sect[k] = str(v)
-        with open(CONFIG_PATH, 'w') as f:
+        old_share = config.get("Offline", "share_name", fallback=self.off_share_name.get()).strip()
+
+        if "Offline" not in config:
+            config["Offline"] = {}
+        o = config["Offline"]
+        o["enabled"]               = str(bool(self.off_enabled.get()))
+        o["host_name"]             = self.off_host_name.get().strip()
+        o["host_ip"]               = self.off_host_ip.get().strip()
+        o["share_name"]            = self.off_share_name.get().strip()
+        o["local_data_root"]       = os.path.normpath(self.off_local_root.get().strip())
+        o["working_fuser_subdir"]  = self.off_work_subdir.get().strip()
+        o["use_ip_unc"]            = str(bool(self.off_use_ip_unc.get()))
+
+        with open(CONFIG_PATH, "w", encoding="utf-8") as f:
             config.write(f)
-        apply_offline_settings()
-        self._refresh_offline_resolved()
+
+        new_share = o["share_name"]
+        if new_share and new_share.lower() != old_share.lower():
+            propagate_share_rename_in_config(old_share, new_share)
+
+        if self.off_enabled.get():
+            ensure_offline_share_exists(log=lambda m: print("[Offline]", m))
+
+        messagebox.showinfo("Settings", "Offline/Shared settings saved.")
 
     def _test_offline_access(self):
-        path = working_fuser_unc(self._collect_offline_inputs())
-        if can_access_unc(path):
-            messagebox.showinfo("Offline Mode", f"Access OK: {path}")
+        o = get_offline_cfg()
+        unc = resolve_network_working_folder_from_cfg(o)
+        if can_access_unc(unc):
+            messagebox.showinfo("Offline Access", f"Access OK:\n{unc}\n\nOpening Explorer…")
+            open_in_explorer(unc)
         else:
-            messagebox.showerror("Offline Mode", OFFLINE_ACCESS_HINT)
+            messagebox.showerror(
+                "Offline Access",
+                f"Cannot access:\n{unc}\n\n"
+                "If this is a local, offline LAN:\n"
+                " • Ensure all PCs are on the same switch\n"
+                " • Static IPs (e.g., 192.168.50.10/24 host)\n"
+                " • Share exists and permissions allow read/write\n"
+                " • Try toggling 'Use IP in UNC' or add host to hosts file"
+            )
+
+    def _open_working_folder(self):
+        o = get_offline_cfg()
+        unc = resolve_network_working_folder_from_cfg(o)
+        if can_access_unc(unc):
+            open_in_explorer(unc)
+        else:
+            messagebox.showerror("Open Working Folder", f"Cannot access:\n{unc}\nUse Test Access to diagnose.")
 
     def _save_host(self):
         h = self.host_var.get().strip()

--- a/PythonPorjects/launch_photomesh_preset.py
+++ b/PythonPorjects/launch_photomesh_preset.py
@@ -1,9 +1,11 @@
 from pathlib import Path
 import os
+import re
 import json
 import subprocess
 import configparser
 from typing import Iterable, List
+from tkinter import messagebox, filedialog
 
 # ---------------------------------------------------------------------------
 # PhotoMesh Wizard configuration
@@ -130,6 +132,78 @@ def can_access_unc(path: str) -> bool:
     except Exception:
         return False
 
+
+def _load_json_safe(path: str) -> dict:
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            return json.load(f)
+    except Exception:
+        return {}
+
+
+def _save_json_safe(path: str, data: dict) -> None:
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(data, f, indent=2)
+
+
+def resolve_network_working_folder_from_cfg(o: dict) -> str:
+    """Return UNC to working fuser folder using current Offline settings."""
+    base = o["host_ip"] if o.get("use_ip_unc") else o["host_name"]
+    return rf"\\{base}\{o['share_name']}\{o['working_fuser_subdir']}"
+
+
+def open_in_explorer(path: str) -> None:
+    try:
+        os.startfile(path)
+    except Exception as e:
+        messagebox.showerror("Open Folder", f"Failed to open:\n{path}\n\n{e}")
+
+
+def replace_share_in_unc_path(p: str, old_share: str, new_share: str) -> str:
+    r"""
+    Replace the share segment in a UNC path:
+      \\HOST\OldShare\...  ->  \\HOST\NewShare\...
+    Keep host and trailing subpaths intact.
+    """
+    if not p or not p.startswith("\\\\"):
+        return p
+    parts = p.split("\\")
+    if len(parts) >= 4 and parts[3].lower() == old_share.lower():
+        parts[3] = new_share
+        return "\\".join(parts)
+    return p
+
+
+def propagate_share_rename_in_config(old_share: str, new_share: str) -> None:
+    """
+    Scan every key in config.ini and swap \\HOST\old_share -> \\HOST\new_share.
+    Save config if changes were made.
+    Also update PhotoMesh wizard install JSON (WIZARD_INSTALL_CFG) for NetworkWorkingFolder.
+    """
+    changed = False
+
+    for sect in config.sections():
+        for key, val in list(config[sect].items()):
+            if isinstance(val, str) and val.startswith("\\\\"):
+                new_val = replace_share_in_unc_path(val, old_share, new_share)
+                if new_val != val:
+                    config[sect][key] = new_val
+                    changed = True
+
+    if changed:
+        with open(CONFIG_PATH, "w", encoding="utf-8") as f:
+            config.write(f)
+
+    wiz = _load_json_safe(WIZARD_INSTALL_CFG)
+    if wiz:
+        nwf = wiz.get("NetworkWorkingFolder", "")
+        if isinstance(nwf, str) and nwf.startswith("\\\\"):
+            new_nwf = replace_share_in_unc_path(nwf, old_share, new_share)
+            if new_nwf != nwf:
+                wiz["NetworkWorkingFolder"] = new_nwf
+                _save_json_safe(WIZARD_INSTALL_CFG, wiz)
+
 PRESET_XML = """<?xml version="1.0" encoding="utf-8"?>
 <BuildParametersPreset xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
   <SerializableVersion>8.0.4.50513</SerializableVersion>
@@ -177,23 +251,45 @@ PRESET_XML = """<?xml version="1.0" encoding="utf-8"?>
 """
 
 
-def _load_json(path: str) -> dict:
-    try:
-        with open(path, "r", encoding="utf-8") as f:
-            return json.load(f)
-    except Exception:
-        return {}
+
+def ensure_wizard_user_defaults(
+    preset: str = PRESET_NAME, autostart: bool = True
+) -> None:
+    """Ensure the PhotoMesh Wizard user config selects *preset* and auto-builds."""
+
+    os.makedirs(os.path.dirname(WIZARD_USER_CFG), exist_ok=True)
+    cfg = {
+        "SelectedPreset": preset,
+        "OverrideSettings": True,
+        "AutoBuild": bool(autostart),
+    }
+    with open(WIZARD_USER_CFG, "w", encoding="utf-8") as f:
+        json.dump(cfg, f, indent=2)
 
 
-def _save_json(path: str, data: dict) -> None:
-    os.makedirs(os.path.dirname(path), exist_ok=True)
-    with open(path, "w", encoding="utf-8") as f:
-        json.dump(data, f, indent=2)
+def ensure_wizard_install_defaults() -> None:
+    """Patch the installed Wizard config with network and basic defaults."""
+
+    cfg = _load_json_safe(WIZARD_INSTALL_CFG)
+
+    cfg.setdefault("UseMinimize", True)
+    cfg.setdefault("ClosePMWhenDone", False)
+    cfg.setdefault("OutputWaitTimerSeconds", 10)
+
+    o = get_offline_cfg()
+    cfg["NetworkWorkingFolder"] = resolve_network_working_folder_from_cfg(o)
+
+    ui = cfg.setdefault("DefaultPhotoMeshWizardUI", {})
+    ui.setdefault("ProcessingLevel", "Standard")
+    ui.setdefault("StopOnError", True)
+    ui.setdefault("MaxProcessing", False)
+
+    _save_json_safe(WIZARD_INSTALL_CFG, cfg)
 
 
-def enforce_install_cfg() -> None:
-    """Force required options in the installation-level Wizard config."""
-    cfg = _load_json(WIZARD_INSTALL_CFG)
+def enforce_photomesh_settings() -> None:
+    """Force required options in the install and user Wizard configs."""
+    cfg = _load_json_safe(WIZARD_INSTALL_CFG)
     ui = cfg.setdefault("DefaultPhotoMeshWizardUI", {})
 
     outputs = ui.setdefault("OutputProducts", {})
@@ -215,73 +311,21 @@ def enforce_install_cfg() -> None:
     cfg.setdefault("UseMinimize", True)
     cfg.setdefault("ClosePMWhenDone", False)
     cfg.setdefault("OutputWaitTimerSeconds", 10)
-    cfg["NetworkWorkingFolder"] = resolve_network_working_folder()
+
+    o = get_offline_cfg()
+    cfg["NetworkWorkingFolder"] = resolve_network_working_folder_from_cfg(o)
 
     try:
-        _save_json(WIZARD_INSTALL_CFG, cfg)
+        _save_json_safe(WIZARD_INSTALL_CFG, cfg)
     except PermissionError:
-        print(
-            "⚠️ Unable to write install config (permission). Continuing with user config."
-        )
+        print("⚠️ Unable to write install config (permission). Continuing.")
 
-
-def enforce_user_cfg() -> None:
-    """Write user-level config selecting the preset and enabling auto-build."""
-    cfg = {
+    user_cfg = {
         "SelectedPreset": PRESET_NAME,
         "OverrideSettings": True,
         "AutoBuild": True,
     }
-    _save_json(WIZARD_USER_CFG, cfg)
-
-
-def enforce_photomesh_settings() -> None:
-    """Legacy wrapper to maintain backwards compatibility."""
-    enforce_install_cfg()
-    enforce_user_cfg()
-
-
-def ensure_wizard_user_defaults(
-    preset: str = PRESET_NAME, autostart: bool = True
-) -> None:
-    """Ensure the PhotoMesh Wizard user config selects *preset* and auto-builds."""
-
-    os.makedirs(os.path.dirname(WIZARD_USER_CFG), exist_ok=True)
-    cfg = {
-        "SelectedPreset": preset,
-        "OverrideSettings": True,
-        "AutoBuild": bool(autostart),
-    }
-    with open(WIZARD_USER_CFG, "w", encoding="utf-8") as f:
-        json.dump(cfg, f, indent=2)
-
-
-def ensure_wizard_install_defaults() -> None:
-    """Patch the installed Wizard config with network and basic defaults."""
-
-    path = WIZARD_INSTALL_CFG
-    if not os.path.isfile(path):
-        return
-
-    with open(path, "r", encoding="utf-8") as f:
-        try:
-            cfg = json.load(f)
-        except Exception:
-            cfg = {}
-
-    cfg.setdefault("UseMinimize", True)
-    cfg.setdefault("ClosePMWhenDone", False)
-    cfg.setdefault("OutputWaitTimerSeconds", 10)
-
-    cfg["NetworkWorkingFolder"] = resolve_network_working_folder()
-
-    ui = cfg.setdefault("DefaultPhotoMeshWizardUI", {})
-    ui.setdefault("ProcessingLevel", "Standard")
-    ui.setdefault("StopOnError", True)
-    ui.setdefault("MaxProcessing", False)
-
-    with open(path, "w", encoding="utf-8") as f:
-        json.dump(cfg, f, indent=2)
+    _save_json_safe(WIZARD_USER_CFG, user_cfg)
 
 
 def launch_wizard_cli(project_name: str, project_path: str, folders: List[str]) -> None:
@@ -302,8 +346,7 @@ def launch_wizard_cli(project_name: str, project_path: str, folders: List[str]) 
         return
 
     ensure_preset_exists()
-    enforce_install_cfg()
-    enforce_user_cfg()
+    enforce_photomesh_settings()
     verify_effective_settings()
 
     args = [
@@ -343,8 +386,8 @@ def ensure_preset_exists() -> str:
 
 def verify_effective_settings() -> None:
     """Print a checklist of critical Wizard settings from both configs."""
-    install = _load_json(WIZARD_INSTALL_CFG)
-    user = _load_json(WIZARD_USER_CFG)
+    install = _load_json_safe(WIZARD_INSTALL_CFG)
+    user = _load_json_safe(WIZARD_USER_CFG)
 
     ui = install.get("DefaultPhotoMeshWizardUI", {})
     outputs = ui.get("OutputProducts", {})
@@ -393,8 +436,7 @@ def launch_photomesh_with_preset(project_name: str, project_path: str, image_fol
         raise FileNotFoundError(f"PhotoMeshWizard.exe not found: {WIZARD_EXE}")
 
     ensure_preset_exists()
-    enforce_install_cfg()
-    enforce_user_cfg()
+    enforce_photomesh_settings()
     verify_effective_settings()
 
     args = [


### PR DESCRIPTION
## Summary
- add utilities for UNC path resolution and share renaming
- sync PhotoMesh config with offline settings
- extend settings panel for offline/shared drive management

## Testing
- `python -m py_compile launch_photomesh_preset.py STE_Toolkit.py`


------
https://chatgpt.com/codex/tasks/task_e_68af47238f7883228e9a3bc1fc956f41