### PR TITLE
Add PhotoMesh config guard and process verification

### DIFF
--- a/PythonPorjects/launch_photomesh_preset.py
+++ b/PythonPorjects/launch_photomesh_preset.py
@@ -4,8 +4,10 @@ import re
 import json
 import subprocess
 import configparser
+import time
 from typing import Iterable, List
 from tkinter import messagebox, filedialog
+from pm_config_guard import patch_photomesh_config
 
 # ---------------------------------------------------------------------------
 # PhotoMesh Wizard configuration
@@ -23,6 +25,9 @@ WIZARD_INSTALL_CFG = r"C:\Program Files\Skyline\PhotoMeshWizard\config.json"
 
 # PhotoMesh Wizard executable
 WIZARD_EXE = r"C:\Program Files\Skyline\PhotoMeshWizard\PhotoMeshWizard.exe"
+
+# PhotoMesh main executable for debugging
+PHOTOMESH_EXE = r"C:\Program Files\Skyline\PhotoMesh\PhotoMesh.exe"
 
 # Preset configuration
 PRESET_NAME = "CPP&OBJ"
@@ -332,6 +337,27 @@ def enforce_photomesh_settings() -> None:
     _save_json_safe(WIZARD_USER_CFG, user_cfg)
 
 
+def _debug_photomesh_process(delay: float = 5.0) -> None:
+    """Verify that PhotoMesh.exe launches after the Wizard."""
+    if not os.path.isfile(PHOTOMESH_EXE):
+        print(f"[DEBUG] PhotoMesh executable not found at {PHOTOMESH_EXE}")
+        return
+    time.sleep(delay)
+    try:
+        result = subprocess.run(
+            ["tasklist", "/FI", "IMAGENAME eq PhotoMesh.exe"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if "PhotoMesh.exe" in result.stdout:
+            print("[DEBUG] PhotoMesh.exe process detected")
+        else:
+            print("[DEBUG] PhotoMesh.exe not running after Wizard launch")
+    except Exception as e:
+        print(f"[DEBUG] Could not verify PhotoMesh.exe: {e}")
+
+
 def launch_wizard_cli(project_name: str, project_path: str, folders: List[str]) -> None:
     """Launch the PhotoMesh Wizard with prepared sources via CLI."""
     # Always refresh config first so the latest checkbox state is used
@@ -358,6 +384,11 @@ def launch_wizard_cli(project_name: str, project_path: str, folders: List[str]) 
         )
         return
 
+    try:
+        patch_photomesh_config()
+    except Exception as e:
+        print(f"[WARN] PhotoMesh config not patched: {e}")
+
     ensure_wizard_user_defaults(DEFAULT_WIZARD_PRESET, autostart=True)
     enforce_photomesh_settings()
 
@@ -380,6 +411,8 @@ def launch_wizard_cli(project_name: str, project_path: str, folders: List[str]) 
         from tkinter import messagebox
 
         messagebox.showerror("PhotoMesh Wizard", f"Failed to launch Wizard:\n{e}")
+
+    _debug_photomesh_process()
 
 def ensure_preset_exists() -> str:
     """Ensure the CPP&OBJ preset file exists with the expected content."""

--- a/PythonPorjects/pm_config_guard.py
+++ b/PythonPorjects/pm_config_guard.py
@@ -1,0 +1,76 @@
+import json, os, shutil, time
+from typing import Any, Dict, Tuple
+
+PM_CFG = r"C:\\Program Files\\Skyline\\PhotoMeshWizard\\config.json"
+
+# The ONLY fields we’re allowed to change:
+ALLOWED_TARGETS = {
+    ("DefaultPhotoMeshWizardUI", "OutputProducts", "Model3D"): True,
+    ("DefaultPhotoMeshWizardUI", "OutputProducts", "Ortho"): False,
+    # Uncomment if you also want them forced off:
+    ("DefaultPhotoMeshWizardUI", "OutputProducts", "DSM"): False,
+    ("DefaultPhotoMeshWizardUI", "OutputProducts", "DTM"): False,
+    ("DefaultPhotoMeshWizardUI", "OutputProducts", "LAS"): False,
+}
+
+def _ensure_path(root: Dict[str, Any], path: Tuple[str, ...]) -> Dict[str, Any]:
+    """Create intermediate dicts for the given path and return the parent dict."""
+    d = root
+    for key in path[:-1]:
+        if key not in d or not isinstance(d[key], dict):
+            d[key] = {}
+        d = d[key]
+    return d
+
+def _get(root: Dict[str, Any], path: Tuple[str, ...]) -> Any:
+    d = root
+    for key in path:
+        if not isinstance(d, dict) or key not in d:
+            return None
+        d = d[key]
+    return d
+
+def _set(root: Dict[str, Any], path: Tuple[str, ...], value: Any) -> None:
+    parent = _ensure_path(root, path)
+    parent[path[-1]] = value
+
+def patch_photomesh_config(cfg_path: str = PM_CFG) -> bool:
+    """
+    Apply minimal, whitelisted toggles to PhotoMesh config.
+    Returns True if a write occurred.
+    """
+    if not os.path.isfile(cfg_path):
+        raise FileNotFoundError(f"PhotoMesh config not found: {cfg_path}")
+
+    with open(cfg_path, "r", encoding="utf-8") as f:
+        try:
+            data = json.load(f)
+        except json.JSONDecodeError as e:
+            raise RuntimeError(f"Config is not valid JSON: {e}")
+
+    changed = False
+    before_after = []
+
+    for path, desired in ALLOWED_TARGETS.items():
+        current = _get(data, path)
+        before_after.append((".".join(path), current, desired))
+        if current is not desired:
+            _set(data, path, desired)
+            changed = True
+
+    if changed:
+        # Make a timestamped backup once per run
+        ts = time.strftime("%Y%m%d_%H%M%S")
+        bak = f"{cfg_path}.{ts}.bak"
+        shutil.copy2(cfg_path, bak)
+
+        with open(cfg_path, "w", encoding="utf-8") as f:
+            # Use indent=2 for readability; this does not touch unrelated keys
+            json.dump(data, f, indent=2)
+
+    # Print a quick report
+    print("\n[PhotoMesh config guard]")
+    for key, cur, want in before_after:
+        print(f"  {key:45} current={cur!r}  ->  required={want!r}")
+    print("  wrote_changes:", changed)
+    return changed


### PR DESCRIPTION
## Summary
- add guard module enforcing specific PhotoMesh Wizard output flags with backup and report
- patch launch flow to run guard and debug PhotoMesh.exe process after wizard launch

## Testing
- `python -m py_compile PythonPorjects/pm_config_guard.py PythonPorjects/launch_photomesh_preset.py`


------
https://chatgpt.com/codex/tasks/task_e_68af56aec88883228585c2c68f6bcef9