### PR TITLE
Support local PhotoMesh runs when Offline Mode is disabled

### DIFF
--- a/PythonPorjects/STE_Toolkit.py
+++ b/PythonPorjects/STE_Toolkit.py
@@ -29,11 +29,17 @@ from launch_photomesh_preset import (
     DEFAULT_WIZARD_PRESET,
     get_offline_cfg,
     working_fuser_unc,
-    resolve_network_working_folder,
     ensure_offline_share_exists,
     can_access_unc,
     OFFLINE_ACCESS_HINT,
     enforce_photomesh_settings,
+    _is_offline_enabled,
+    _set_offline_enabled,
+    _load_json_safe,
+    _save_json_safe,
+    _update_wizard_network_mode,
+    WIZARD_INSTALL_CFG,
+    resolve_network_working_folder_from_cfg,
 )
 from collections import OrderedDict
 import time
@@ -1169,10 +1175,12 @@ def count_local_fusers() -> int:
 
 
 def start_fuser_instance():
-    o = get_offline_cfg()
-    if o["enabled"] and not can_access_unc(resolve_network_working_folder()):
-        messagebox.showerror("Offline Mode", OFFLINE_ACCESS_HINT)
-        return False
+    if _is_offline_enabled():
+        o = get_offline_cfg()
+        unc = resolve_network_working_folder_from_cfg(o)
+        if not can_access_unc(unc):
+            messagebox.showerror("Offline Mode", OFFLINE_ACCESS_HINT)
+            return False
 
     exe = find_fuser_exe()
     if not exe:
@@ -1227,8 +1235,7 @@ def enforce_local_fuser_policy():
       - else: 0 fusers (kill all)
     """
     try:
-        o = get_offline_cfg()
-        if not o["enabled"]:
+        if not _is_offline_enabled():
             kill_fusers()
             return
 
@@ -1247,6 +1254,8 @@ def enforce_local_fuser_policy():
 def update_fuser_shared_path(project_path: str | None = None) -> None:
     # If no project path is supplied only update when this machine is marked as
     # a fuser computer
+    if not _is_offline_enabled():
+        return
     if project_path is None and not config['Fusers'].getboolean('fuser_computer', False):
         return
 
@@ -1255,7 +1264,7 @@ def update_fuser_shared_path(project_path: str | None = None) -> None:
 
     stored_host = config['Fusers'].get('working_folder_host', '').strip()
 
-    path = resolve_network_working_folder()
+    path = resolve_network_working_folder_from_cfg(get_offline_cfg())
     if project_path and project_path.startswith('\\'):
         path = project_path
 
@@ -1292,10 +1301,11 @@ def apply_offline_settings() -> None:
     enforce_photomesh_settings()
     update_fuser_shared_path()
 
-    o = get_offline_cfg()
-    local_name = get_machine_name()
-    if o["enabled"] and local_name.upper() == o["host_name"].split('.')[0].upper():
-        ensure_offline_share_exists()
+    if _is_offline_enabled():
+        o = get_offline_cfg()
+        local_name = get_machine_name()
+        if local_name.upper() == o["host_name"].split('.')[0].upper():
+            ensure_offline_share_exists()
 
     enforce_local_fuser_policy()
 
@@ -3288,9 +3298,8 @@ class VBS4Panel(tk.Frame):
                 return {}, None
 
         fuser_settings, default_path = load_fuser_config(config_file)
-        o = get_offline_cfg()
-        if o["enabled"]:
-            default_path = resolve_network_working_folder()
+        if _is_offline_enabled():
+            default_path = resolve_network_working_folder_from_cfg(get_offline_cfg())
             if not can_access_unc(default_path):
                 messagebox.showerror("Offline Mode", OFFLINE_ACCESS_HINT)
                 return
@@ -3361,9 +3370,8 @@ class VBS4Panel(tk.Frame):
                 self.log_message(f"Failed to load fuser config: {e}")
                 return None
 
-        o = get_offline_cfg()
-        if o["enabled"]:
-            default_path = resolve_network_working_folder()
+        if _is_offline_enabled():
+            default_path = resolve_network_working_folder_from_cfg(get_offline_cfg())
             if not can_access_unc(default_path):
                 messagebox.showerror("Offline Mode", OFFLINE_ACCESS_HINT)
                 return
@@ -3902,16 +3910,16 @@ class SettingsPanel(tk.Frame):
         )
         offline.grid(row=3, column=0, sticky="ew", padx=10, pady=(0, 6))
 
-        self.offline_enabled_var = tk.BooleanVar(value=off_cfg["enabled"])
+        self.offline_var = tk.BooleanVar(value=_is_offline_enabled())
         tk.Checkbutton(
             offline,
             text="Enable Offline Mode",
-            variable=self.offline_enabled_var,
+            variable=self.offline_var,
             font=("Helvetica", 16),
             bg="#444444",
             fg="white",
             selectcolor="#444444",
-            command=self._refresh_offline_resolved,
+            command=self._on_offline_toggle,
         ).pack(anchor="w", pady=2)
 
         row = tk.Frame(offline, bg="black")
@@ -4048,7 +4056,7 @@ class SettingsPanel(tk.Frame):
         btn_row.pack(anchor="w", pady=(4, 0))
 
         for var in [
-            self.offline_enabled_var,
+            self.offline_var,
             self.offline_host_name_var,
             self.offline_host_ip_var,
             self.offline_share_var,
@@ -4183,7 +4191,7 @@ class SettingsPanel(tk.Frame):
 
     def _collect_offline_inputs(self) -> dict:
         return {
-            "enabled": self.offline_enabled_var.get(),
+            "enabled": self.offline_var.get(),
             "host_name": self.offline_host_name_var.get().strip(),
             "host_ip": self.offline_host_ip_var.get().strip(),
             "share_name": self.offline_share_var.get().strip(),
@@ -4195,6 +4203,18 @@ class SettingsPanel(tk.Frame):
     def _refresh_offline_resolved(self, *args):
         path = working_fuser_unc(self._collect_offline_inputs())
         self.offline_resolved_var.set(f"Resolved Working Folder: {path}")
+
+    def _on_offline_toggle(self):
+        val = bool(self.offline_var.get())
+        _set_offline_enabled(val)
+        try:
+            cfg = _load_json_safe(WIZARD_INSTALL_CFG)
+            _update_wizard_network_mode(cfg)
+            _save_json_safe(WIZARD_INSTALL_CFG, cfg)
+        except Exception:
+            pass
+        messagebox.showinfo("Offline Mode", "Offline Mode is now " + ("ENABLED" if val else "DISABLED"))
+        self._refresh_offline_resolved()
 
     def _save_offline_settings(self):
         o = self._collect_offline_inputs()

--- a/PythonPorjects/config.ini
+++ b/PythonPorjects/config.ini
@@ -28,9 +28,9 @@ working_folder_host = Kit1-1
 path = C:\BiSim OneClick\Datasets\CACTF_BUILD_20250814_134554
 
 [Offline]
-enabled = True
-host_name = 
-host_ip = 
+enabled = False
+host_name = KIT-HOST
+host_ip = 192.168.50.10
 share_name = SharedMeshDrive
 local_data_root = D:\SharedMeshDrive
 working_fuser_subdir = WorkingFuser


### PR DESCRIPTION
## Summary
- disable Offline Mode by default and provide helper functions to read/set the state
- update PhotoMesh config writers and launch paths to remove NetworkWorkingFolder when offline is off
- allow settings UI to toggle Offline Mode immediately and refresh the wizard network mode

## Testing
- `python -m py_compile PythonPorjects/launch_photomesh_preset.py PythonPorjects/STE_Toolkit.py`


------
https://chatgpt.com/codex/tasks/task_e_68af89f73ea48322b43fb4f349f6e18d