### PR TITLE
Add PhotoMesh preset management and wizard launch helpers

### DIFF
--- a/PythonPorjects/photomesh/__init__.py
+++ b/PythonPorjects/photomesh/__init__.py
@@ -1,0 +1,22 @@
+"""PhotoMesh helper utilities."""
+
+from .bootstrap import (
+    ensure_oeccp_preset_in_appdata,
+    set_default_preset_in_presetsettings,
+    set_user_wizard_defaults,
+    enforce_install_cfg_obj_only,
+    find_wizard_exe,
+    launch_wizard_with_preset,
+    verify_effective_settings,
+)
+
+__all__ = [
+    "ensure_oeccp_preset_in_appdata",
+    "set_default_preset_in_presetsettings",
+    "set_user_wizard_defaults",
+    "enforce_install_cfg_obj_only",
+    "find_wizard_exe",
+    "launch_wizard_with_preset",
+    "verify_effective_settings",
+]
+

--- a/PythonPorjects/photomesh/bootstrap.py
+++ b/PythonPorjects/photomesh/bootstrap.py
@@ -1,31 +1,62 @@
-import os
+"""Utility functions for preparing and launching PhotoMesh Wizard.
+
+This module makes sure the custom ``OECPP`` preset is available for the
+current user and that PhotoMesh defaults to OBJ output only.  The functions are
+idempotent and safe to call on every run so new user profiles or Skyline
+updates do not break the desired behaviour.
+
+Typical usage::
+
+    ensure_oeccp_preset_in_appdata(repo_hint)
+    set_default_preset_in_presetsettings()
+    set_user_wizard_defaults()
+    enforce_install_cfg_obj_only()  # best effort, requires admin
+    launch_wizard_with_preset(name, path, folders)
+
+"""
+
+from __future__ import annotations
+
 import json
+import os
 import shutil
-import logging
-import filecmp
 import subprocess
+import logging
 import xml.etree.ElementTree as ET
 from typing import Callable, List
 
 PRESET_NAME = "OECPP"
 PRESET_FILENAME = f"{PRESET_NAME}.PMPreset"
 
+# common paths ---------------------------------------------------------------
+
+ARR = "http://schemas.microsoft.com/2003/10/Serialization/Arrays"
+XMLNS = "http://www.w3.org/2000/xmlns/"
+
 PROGRAM_FILES = os.getenv("ProgramFiles", r"C:\\Program Files")
-WIZARD_DIR = os.path.join(PROGRAM_FILES, "Skyline", "PhotoMesh", "Tools", "PhotomeshWizard")
+WIZARD_DIR = os.path.join(
+    PROGRAM_FILES, "Skyline", "PhotoMesh", "Tools", "PhotomeshWizard"
+)
 INSTALL_CFG = os.path.join(WIZARD_DIR, "config.json")
 
-APPDATA = os.getenv("APPDATA") or os.path.join(os.path.expanduser("~"), "AppData", "Roaming")
+APPDATA = os.getenv("APPDATA") or os.path.join(
+    os.path.expanduser("~"), "AppData", "Roaming"
+)
 USER_PRESET_DIR = os.path.join(APPDATA, "Skyline", "PhotoMesh", "Presets")
 USER_PRESET_PATH = os.path.join(USER_PRESET_DIR, PRESET_FILENAME)
 USER_PRESET_SETTINGS = os.path.join(USER_PRESET_DIR, "PresetSettings.xml")
 USER_CFG = os.path.join(APPDATA, "Skyline", "PhotoMesh", "Wizard", "config.json")
 
 
+# helpers -------------------------------------------------------------------
+
 def _is_admin() -> bool:
-    """Return True if running with administrative privileges."""
+    """Return ``True`` if the process has administrative rights."""
+
     if os.name == "nt":
-        try:
+        try:  # pragma: no cover - platform specific
             import ctypes
+
             return bool(ctypes.windll.shell32.IsUserAnAdmin())
         except Exception:
             return False
@@ -34,6 +65,7 @@ def _is_admin() -> bool:
 
 def _find_file_recursive(start_dir: str, filename: str, max_depth: int = 6) -> str | None:
     """Search for *filename* under *start_dir* up to *max_depth* levels."""
+
     start_dir = os.path.abspath(start_dir)
     for root, dirs, files in os.walk(start_dir):
         depth = root[len(start_dir) :].count(os.sep)
@@ -45,7 +77,8 @@ def _find_file_recursive(start_dir: str, filename: str, max_depth: int = 6) -> s
 
 
 def _load_json(path: str) -> dict:
-    """Load JSON file from *path* returning empty dict on failure."""
+    """Load JSON from *path*, returning an empty dict on failure."""
+
     try:
         with open(path, "r", encoding="utf-8") as fh:
             return json.load(fh)
@@ -59,142 +92,119 @@ def _save_json(path: str, data: dict) -> None:
         json.dump(data, fh, indent=2)
 
 
-def _preset_dst_for_profile(profile_dir: str) -> str:
-    return os.path.join(
-        profile_dir,
-        "AppData",
-        "Roaming",
-        "Skyline",
-        "PhotoMesh",
-        "Presets",
-        PRESET_FILENAME,
+# core functionality ---------------------------------------------------------
+
+def ensure_oeccp_preset_in_appdata(repo_hint: str) -> str:
+    """Copy and sanitise the ``OECPP`` preset into the user's AppData.
+
+    The preset is located using *repo_hint* or by searching recursively up to
+    six levels deep.  It is copied to ``%APPDATA%\\Skyline\\PhotoMesh\\Presets``
+    and then adjusted so it is marked as default, last used and outputs OBJ
+    only.
+
+    Returns the full path to the copied preset.
+    """
+
+    repo_hint = os.path.abspath(repo_hint)
+    preset_src = (
+        repo_hint
+        if os.path.isfile(repo_hint)
+        else _find_file_recursive(os.path.dirname(repo_hint), PRESET_FILENAME)
     )
+    if not preset_src:
+        raise FileNotFoundError(
+            f"Preset {PRESET_FILENAME} not found starting from {repo_hint}"
+        )
 
+    os.makedirs(USER_PRESET_DIR, exist_ok=True)
+    shutil.copy2(preset_src, USER_PRESET_PATH)
 
-def _preset_settings_xml_for_profile(profile_dir: str) -> str:
-    return os.path.join(
-        profile_dir,
-        "AppData",
-        "Roaming",
-        "Skyline",
-        "PhotoMesh",
-        "Presets",
-        "PresetSettings.xml",
-    )
-
-
-def _user_cfg_for_profile(profile_dir: str) -> str:
-    return os.path.join(
-        profile_dir,
-        "AppData",
-        "Roaming",
-        "Skyline",
-        "PhotoMesh",
-        "Wizard",
-        "config.json",
-    )
-
-
-# ---------------------------------------------------------------------------
-# Internal helpers
-# ---------------------------------------------------------------------------
-
-def _apply_profile_settings(profile_dir: str, preset_src: str, autostart: bool) -> None:
-    """Copy preset and enforce defaults for a given user profile."""
+    # adjust XML inside the preset
     try:
-        dst = _preset_dst_for_profile(profile_dir)
-        os.makedirs(os.path.dirname(dst), exist_ok=True)
-        if not os.path.isfile(dst) or not filecmp.cmp(preset_src, dst, False):
-            shutil.copy2(preset_src, dst)
+        tree = ET.parse(USER_PRESET_PATH)
+        root = tree.getroot()
+    except Exception:
+        root = ET.Element("BuildParametersPreset")
+        tree = ET.ElementTree(root)
 
-        # PresetSettings.xml
-        xml_path = _preset_settings_xml_for_profile(profile_dir)
-        os.makedirs(os.path.dirname(xml_path), exist_ok=True)
-        if os.path.isfile(xml_path):
-            try:
-                tree = ET.parse(xml_path)
-                root = tree.getroot()
-            except Exception:
-                root = ET.Element("PresetSettings")
-                tree = ET.ElementTree(root)
-        else:
+    # ensure expected fields
+    for tag in ("IsDefault", "IsLastUsed"):
+        elem = root.find(tag)
+        if elem is None:
+            elem = ET.SubElement(root, tag)
+        elem.text = "true"
+
+    name = root.find("PresetName")
+    if name is None:
+        name = ET.SubElement(root, "PresetName")
+    name.text = PRESET_NAME
+
+    bp = root.find("BuildParameters")
+    if bp is None:
+        bp = ET.SubElement(root, "BuildParameters")
+    out = bp.find("OutputFormats")
+    if out is None:
+        out = ET.SubElement(bp, "OutputFormats")
+    out.attrib.clear()
+    out.set(f"{{{XMLNS}}}d3p1", ARR)
+    for child in list(out):
+        out.remove(child)
+    ET.SubElement(out, f"{{{ARR}}}string").text = "OBJ"
+
+    ET.register_namespace("d3p1", ARR)
+    tree.write(USER_PRESET_PATH, encoding="utf-8", xml_declaration=True)
+    return USER_PRESET_PATH
+
+
+def set_default_preset_in_presetsettings(preset_name: str = PRESET_NAME) -> None:
+    """Ensure ``PresetSettings.xml`` points to *preset_name* as default."""
+
+    os.makedirs(USER_PRESET_DIR, exist_ok=True)
+    if os.path.isfile(USER_PRESET_SETTINGS):
+        try:
+            tree = ET.parse(USER_PRESET_SETTINGS)
+            root = tree.getroot()
+        except Exception:
             root = ET.Element("PresetSettings")
             tree = ET.ElementTree(root)
-        default = root.find("DefaultPresetNames")
-        if default is None:
-            default = ET.SubElement(root, "DefaultPresetNames")
-        for child in list(default):
-            default.remove(child)
-        ET.SubElement(default, "string").text = PRESET_NAME
-        tree.write(xml_path, encoding="utf-8", xml_declaration=True)
+    else:
+        root = ET.Element("PresetSettings")
+        tree = ET.ElementTree(root)
 
-        # User config
-        cfg_path = _user_cfg_for_profile(profile_dir)
-        cfg = _load_json(cfg_path)
-        cfg.update(
-            {
-                "OverrideSettings": True,
-                "AutoBuild": bool(autostart),
-                "SelectedPreset": PRESET_NAME,
-                "DefaultPresetName": PRESET_NAME,
-            }
-        )
-        _save_json(cfg_path, cfg)
-    except Exception as exc:  # pragma: no cover - continue on error
-        logging.warning("Failed to seed profile %s: %s", profile_dir, exc)
+    dn = root.find("DefaultPresetNames")
+    if dn is None:
+        dn = ET.SubElement(root, "DefaultPresetNames")
+    for child in list(dn):
+        dn.remove(child)
+    ET.SubElement(dn, f"{{{ARR}}}string").text = preset_name
+
+    ET.register_namespace("d2p1", ARR)
+    tree.write(USER_PRESET_SETTINGS, encoding="utf-8", xml_declaration=True)
 
 
-# ---------------------------------------------------------------------------
-# Public API
-# ---------------------------------------------------------------------------
+def set_user_wizard_defaults(preset: str = PRESET_NAME, autostart: bool = True) -> None:
+    """Write wizard ``config.json`` with our desired defaults."""
 
-def seed_preset_everywhere(repo_hint: str, also_set_default_profile: bool = True) -> None:
-    """Copy preset into all user profiles and set defaults."""
-    repo_hint = os.path.abspath(repo_hint)
-    preset_src = repo_hint if os.path.isfile(repo_hint) else _find_file_recursive(
-        os.path.dirname(repo_hint), PRESET_FILENAME
+    cfg = _load_json(USER_CFG)
+    cfg.update(
+        {
+            "OverrideSettings": True,
+            "AutoBuild": bool(autostart),
+            "SelectedPreset": preset,
+            "DefaultPresetName": preset,
+        }
     )
-    if not preset_src:
-        raise FileNotFoundError(f"Preset {PRESET_FILENAME} not found from {repo_hint}")
-
-    users_root = os.path.join(os.getenv("SystemDrive", "C:"), "Users")
-    try:
-        names = os.listdir(users_root)
-    except FileNotFoundError:  # pragma: no cover
-        names = []
-
-    profiles = []
-    for name in names:
-        if not also_set_default_profile and name.lower() in {"default"}:
-            continue
-        path = os.path.join(users_root, name)
-        if os.path.isdir(path):
-            profiles.append(path)
-
-    for profile in profiles:
-        _apply_profile_settings(profile, preset_src, True)
+    _save_json(USER_CFG, cfg)
 
 
-def prepare_photomesh_environment_per_user(repo_hint: str, autostart: bool = True) -> None:
-    """Ensure the current user's preset and configs are correct."""
-    repo_hint = os.path.abspath(repo_hint)
-    preset_src = repo_hint if os.path.isfile(repo_hint) else _find_file_recursive(
-        os.path.dirname(repo_hint), PRESET_FILENAME
-    )
-    if not preset_src:
-        raise FileNotFoundError(f"Preset {PRESET_FILENAME} not found from {repo_hint}")
+def enforce_install_cfg_obj_only() -> bool:
+    """Best-effort enforcement of OBJ-only output in the install config.
 
-    profile_dir = os.path.dirname(os.path.dirname(APPDATA))
-    _apply_profile_settings(profile_dir, preset_src, autostart)
+    Returns ``True`` if the configuration file was written.  The function
+    silently skips when not running with administrative privileges or when the
+    install configuration file is missing.
+    """
 
-
-def enforce_install_cfg_obj_only(
-    center_pivot: bool = True,
-    ellipsoid: bool = True,
-    disable_ortho: bool = True,
-    obj_only: bool = True,
-) -> bool:
-    """Write install-level Wizard config enforcing OBJ-only output."""
     if not _is_admin() or not os.path.isfile(INSTALL_CFG):
         return False
 
@@ -202,29 +212,26 @@ def enforce_install_cfg_obj_only(
     ui = cfg.setdefault("DefaultPhotoMeshWizardUI", {})
     outputs = ui.setdefault("OutputProducts", {})
     outputs["3DModel"] = True
-    if disable_ortho:
-        outputs["Ortho"] = False
+    outputs["Ortho"] = False
     m3d = ui.setdefault("Model3DFormats", {})
-    if obj_only:
-        for key in list(m3d.keys()):
-            if isinstance(m3d[key], bool):
-                m3d[key] = False
-        m3d["OBJ"] = True
-        m3d["3DML"] = False
-    if center_pivot:
-        ui["CenterPivotToProject"] = True
-    if ellipsoid:
-        ui["ReprojectToEllipsoid"] = True
+    for key in list(m3d.keys()):
+        if isinstance(m3d[key], bool):
+            m3d[key] = False
+    m3d["OBJ"] = True
+    m3d["3DML"] = False
+    ui["CenterPivotToProject"] = True
+    ui["ReprojectToEllipsoid"] = True
 
     try:
         _save_json(INSTALL_CFG, cfg)
         return True
-    except Exception:  # pragma: no cover
+    except Exception:  # pragma: no cover - disk write failure
         return False
 
 
 def find_wizard_exe() -> str:
     """Return full path to the PhotoMesh Wizard executable."""
+
     for name in ("PhotoMeshWizard.exe", "WizardGUI.exe"):
         path = os.path.join(WIZARD_DIR, name)
         if os.path.isfile(path):
@@ -233,9 +240,13 @@ def find_wizard_exe() -> str:
 
 
 def launch_wizard_with_preset(
-    project_name: str, project_path: str, folders: List[str], preset_name: str = PRESET_NAME
+    project_name: str,
+    project_path: str,
+    folders: List[str],
+    preset: str = PRESET_NAME,
 ) -> subprocess.Popen:
-    """Launch the PhotoMesh Wizard with provided folders and preset."""
+    """Launch the PhotoMesh Wizard with the supplied preset and folders."""
+
     exe = find_wizard_exe()
     args = [
         exe,
@@ -245,7 +256,7 @@ def launch_wizard_with_preset(
         project_path,
         "--overrideSettings",
         "--preset",
-        preset_name,
+        preset,
     ]
     for fld in folders:
         args += ["--folder", fld]
@@ -253,20 +264,58 @@ def launch_wizard_with_preset(
 
 
 def verify_effective_settings(log: Callable[[str], None] = print) -> None:
-    """Log selected output products and formats from configs."""
+    """Log resolved values from the preset, user and install configs."""
+
+    # Preset details ---------------------------------------------------------
+    try:
+        tree = ET.parse(USER_PRESET_PATH)
+        bp = tree.getroot().find("BuildParameters")
+        outputs = []
+        if bp is not None:
+            out = bp.find("OutputFormats")
+            if out is not None:
+                outputs = [child.text for child in out]
+        log(f"Preset OutputFormats: {outputs}")
+    except Exception:
+        log("Preset OutputFormats: <error>")
+
+    # PresetSettings ---------------------------------------------------------
+    try:
+        ps_tree = ET.parse(USER_PRESET_SETTINGS)
+        dn = ps_tree.getroot().find("DefaultPresetNames")
+        names = [child.text for child in dn] if dn is not None else []
+        log(f"PresetSettings DefaultPresetNames: {names}")
+    except Exception:
+        log("PresetSettings DefaultPresetNames: <error>")
+
+    # Install config ---------------------------------------------------------
     install = _load_json(INSTALL_CFG)
-    user = _load_json(USER_CFG)
     ui = install.get("DefaultPhotoMeshWizardUI", {})
     outputs = ui.get("OutputProducts", {})
-    m3d = ui.get("Model3DFormats", {})
+    formats = ui.get("Model3DFormats", {})
     log(
-        f"OutputProducts: 3DModel={outputs.get('3DModel')} Ortho={outputs.get('Ortho')}"
-    )
-    log(f"Model3DFormats: OBJ={m3d.get('OBJ')} 3DML={m3d.get('3DML')}")
-    log(
-        f"CenterPivotToProject={ui.get('CenterPivotToProject')} "
-        f"ReprojectToEllipsoid={ui.get('ReprojectToEllipsoid')}"
+        "Install OutputProducts: 3DModel={0} Ortho={1}".format(
+            outputs.get("3DModel"), outputs.get("Ortho")
+        )
     )
     log(
-        f"UserConfig: AutoBuild={user.get('AutoBuild')} SelectedPreset={user.get('SelectedPreset')}"
+        "Install Model3DFormats: OBJ={0} 3DML={1}".format(
+            formats.get("OBJ"), formats.get("3DML")
+        )
     )
+    log(
+        "Install CenterPivotToProject={0} ReprojectToEllipsoid={1}".format(
+            ui.get("CenterPivotToProject"), ui.get("ReprojectToEllipsoid")
+        )
+    )
+
+    # User config ------------------------------------------------------------
+    user = _load_json(USER_CFG)
+    log(
+        "UserConfig: AutoBuild={0} SelectedPreset={1} DefaultPresetName={2}".format(
+            user.get("AutoBuild"),
+            user.get("SelectedPreset"),
+            user.get("DefaultPresetName"),
+        )
+    )
+


### PR DESCRIPTION
## Summary
- manage OECPP preset and defaults under user AppData
- enforce OBJ-only output and center/ellipsoid wizard settings
- add helpers to launch wizard with preset and verify configuration

## Testing
- `python -m py_compile VBS4Project/PythonPorjects/photomesh/bootstrap.py VBS4Project/PythonPorjects/photomesh/__init__.py`


------
https://chatgpt.com/codex/tasks/task_e_68b0557767ac8322a22d5d24882409e6