### PR TITLE
Cleanly mount One-Click Terrain panel

### DIFF
--- a/PythonPorjects/STE_Toolkit.py
+++ b/PythonPorjects/STE_Toolkit.py
@@ -2664,7 +2664,7 @@ class VBS4Panel(tk.Frame):
         self.btn_oneclick_toggle.bind("<Leave>", self.hide_tooltip)
 
         self.oneclick_slot = tk.Frame(self, bg=self.cget("bg"))
-        self.oneclick_slot.pack(fill="x")
+        # don't pack here; we'll mount only when expanded
         self.oneclick_group = None
         self.update_fuser_state()
 
@@ -2969,16 +2969,28 @@ class VBS4Panel(tk.Frame):
         else:
             self._expand_oneclick()
 
+    def _wrap_autocollapse(self, fn):
+        def _inner(*args, **kwargs):
+            try:
+                return fn(*args, **kwargs)
+            finally:
+                # collapse shortly after the action to keep UI responsive
+                self.after(10, self._collapse_oneclick)
+        return _inner
+
     def _expand_oneclick(self):
         if self.oneclick_group:
             return
         self.oneclick_open = True
         self.btn_oneclick_toggle.config(text="Hide Terrain Options")
+        # mount the slot now (so closing can fully remove it)
+        if not self.oneclick_slot.winfo_ismapped():
+            self.oneclick_slot.pack(fill="x", pady=(4, 10))
 
         self.oneclick_group = tk.Frame(
             self.oneclick_slot, bg=self.oneclick_slot.cget('bg')
         )
-        self.oneclick_group.pack(fill='x', pady=(4, 10))
+        self.oneclick_group.pack(fill='x')
 
         panel = tk.Frame(self.oneclick_group, bg="#333333")
         panel.pack(fill='x', padx=0, pady=0)
@@ -2997,22 +3009,23 @@ class VBS4Panel(tk.Frame):
 
         pb = globals().get("pill_button")
         if pb:
-            pb(panel, "One-Click Conversion", self.on_oneclick_convert)\
+            pb(panel, "One-Click Conversion", self._wrap_autocollapse(self.on_oneclick_convert))\
                 .pack(pady=8, ipadx=10, ipady=5)
-            pb(panel, "Launch Reality Mesh to VBS4", self.on_launch_reality_mesh)\
+            pb(panel, "Launch Reality Mesh to VBS4", self._wrap_autocollapse(self.on_launch_reality_mesh))\
                 .pack(pady=8, ipadx=10, ipady=5)
-            pb(panel, "One-Click Terrain Tutorial", self.on_open_oct_tutorial)\
+            pb(panel, "One-Click Terrain Tutorial", self._wrap_autocollapse(self.on_open_oct_tutorial))\
                 .pack(pady=8, ipadx=10, ipady=5)
         else:
-            tk.Button(panel, text="One-Click Conversion", command=self.on_oneclick_convert,
+            tk.Button(panel, text="One-Click Conversion",
+                      command=self._wrap_autocollapse(self.on_oneclick_convert),
                       font=("Helvetica", 20), bg="#444444", fg="white", bd=0,
                       highlightthickness=0).pack(pady=8, ipadx=10, ipady=5)
             tk.Button(panel, text="Launch Reality Mesh to VBS4",
-                      command=self.on_launch_reality_mesh,
+                      command=self._wrap_autocollapse(self.on_launch_reality_mesh),
                       font=("Helvetica", 20), bg="#444444", fg="white", bd=0,
                       highlightthickness=0).pack(pady=8, ipadx=10, ipady=5)
             tk.Button(panel, text="One-Click Terrain Tutorial",
-                      command=self.on_open_oct_tutorial,
+                      command=self._wrap_autocollapse(self.on_open_oct_tutorial),
                       font=("Helvetica", 20), bg="#444444", fg="white", bd=0,
                       highlightthickness=0).pack(pady=8, ipadx=10, ipady=5)
 
@@ -3025,13 +3038,21 @@ class VBS4Panel(tk.Frame):
             self.controller.update_navigation()
 
     def _collapse_oneclick(self):
-        if not self.oneclick_group:
+        if not self.oneclick_open and not self.oneclick_group:
             return
         self.oneclick_open = False
         self.btn_oneclick_toggle.config(text="One-Click Terrain Options")
-        self.oneclick_group.pack_forget()
-        self.oneclick_group.destroy()
-        self.oneclick_group = None
+        # destroy the inner group if present
+        if self.oneclick_group:
+            try:
+                self.oneclick_group.pack_forget()
+                self.oneclick_group.destroy()
+            except Exception:
+                pass
+            self.oneclick_group = None
+        # unmount the slot to avoid a leftover black box
+        if self.oneclick_slot.winfo_ismapped():
+            self.oneclick_slot.pack_forget()
         try:
             self.btn_oneclick_toggle.focus_set()
         except Exception:
@@ -3043,7 +3064,7 @@ class VBS4Panel(tk.Frame):
         self.one_click_conversion()
 
     def on_launch_reality_mesh(self):
-     self.launch_reality_mesh_to_vbs4()
+        self.launch_reality_mesh_to_vbs4()
 
     def on_open_oct_tutorial(self):
         self.show_terrain_tutorial()


### PR DESCRIPTION
## Summary
- Avoid pre-packing One-Click Terrain slot and mount/unmount dynamically
- Auto-collapse One-Click Terrain options after actions
- Remove leftover space by fully unmounting the panel on collapse

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b089ec7760832286459eb9e44fca60

## Summary by Sourcery

Enable dynamic mounting and unmounting of the One-Click Terrain panel to eliminate leftover space and add automatic collapse behavior after actions

Enhancements:
- Mount the One-Click Terrain slot only when expanded and unmount it on collapse to avoid residual UI space
- Add _wrap_autocollapse decorator to auto-collapse the terrain panel shortly after action callbacks
- Update all One-Click buttons to use the autocollapse wrapper for seamless UI responsiveness
- Fully destroy the oneclick_group frame and unmount its slot on collapse with error handling for clean teardown