### PR TITLE
feat: support new PhotoMesh Wizard path

### DIFF
--- a/PythonPorjects/STE_Toolkit.py
+++ b/PythonPorjects/STE_Toolkit.py
@@ -671,36 +671,45 @@ def set_active_wizard_preset(preset_name="CPP&OBJ"):
 
     print(f"✅ Set {preset_name} as active preset in Wizard config")
 
+def _wizard_install_config_paths() -> list[str]:
+    return [
+        r"C:\\Program Files\\Skyline\\PhotoMeshWizard\\config.json",                 # NEW
+        r"C:\\Program Files\\Skyline\\PhotoMesh\\Tools\\PhotomeshWizard\\config.json", # legacy
+    ]
+
 
 def enable_obj_in_photomesh_config():
- config_path = r"C:\Program Files\Skyline\PhotoMeshWizard\config.json"
+    import json, os
+    updated_any = False
+    for config_path in _wizard_install_config_paths():
+        if not os.path.isfile(config_path):
+            continue
+        try:
+            with open(config_path, "r", encoding="utf-8") as f:
+                cfg = json.load(f)
+            ui = cfg.setdefault("DefaultPhotoMeshWizardUI", {})
+            outs = ui.setdefault("OutputProducts", {})
+            outs["3DModel"] = True
+            outs["Ortho"] = False
+            m3d = ui.setdefault("Model3DFormats", {})
+            # turn all bools off then enable OBJ
+            for k, v in list(m3d.items()):
+                if isinstance(v, bool):
+                    m3d[k] = False
+            m3d["OBJ"] = True
+            m3d["3DML"] = False
+            ui["CenterPivotToProject"] = True
+            ui["CenterModelsToProject"] = True
+            ui["ReprojectToEllipsoid"] = True
 
- config_path = r"C:\Program Files\Skyline\PhotoMeshWizard\config.json"
-
- try:
-    with open(config_path, 'r') as f:
-        config = json.load(f)
-
-    # Ensure the structure exists before editing
-    if "DefaultPhotoMeshWizardUI" not in config:
-        config["DefaultPhotoMeshWizardUI"] = {}
-    if "Model3DFormats" not in config["DefaultPhotoMeshWizardUI"]:
-        config["DefaultPhotoMeshWizardUI"]["Model3DFormats"] = {}
-
-    # ✅ Enable OBJ
-    config["DefaultPhotoMeshWizardUI"]["Model3DFormats"]["OBJ"] = True
-
-    # ❌ Disable 3DML
-    config["DefaultPhotoMeshWizardUI"]["Model3DFormats"]["3DML"] = False
-
-    # Save changes
-    with open(config_path, 'w') as f:
-        json.dump(config, f, indent=4)
-
-    print("✅ OBJ enabled and 3DML disabled in config.json")
-
- except Exception as e:
-        print(f"❌ Failed to update config.json: {e}")
+            with open(config_path, "w", encoding="utf-8") as f:
+                json.dump(cfg, f, indent=2)
+            print(f"✅ Updated Wizard config at: {config_path}")
+            updated_any = True
+        except Exception as e:
+            print(f"⚠️ Failed to update {config_path}: {e}")
+    if not updated_any:
+        print("❌ No install-level Wizard config.json found to update")
 
 def _copytree_progress(src: str, dst: str, progress_cb=None) -> None:
     """Recursively copy *src* to *dst* reporting progress."""


### PR DESCRIPTION
## Summary
- detect PhotoMesh Wizard in new or legacy install locations
- update toolkit config updater to write to both potential install configs
- launch PhotoMesh Wizard using detected installation directory

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b21a85c0208322ab5183555a8bb798

## Summary by Sourcery

Add support for the new PhotoMesh Wizard install path alongside the legacy one by detecting the install directory, updating multiple config locations, and dynamically resolving the executable before launch

New Features:
- Detect PhotoMesh Wizard installation directory across new and legacy paths with a filesystem fallback
- Dynamically locate the PhotoMesh Wizard executable from possible filenames
- Update enable_obj_in_photomesh_config to apply settings to both new and legacy config.json locations

Enhancements:
- Use the detected install directory (WIZARD_DIR) as the working directory for launching the wizard