### PR TITLE
feat: prefer new PhotoMesh Wizard path

### DIFF
--- a/PythonPorjects/launch_photomesh_preset.py
+++ b/PythonPorjects/launch_photomesh_preset.py
@@ -18,20 +18,36 @@ WIZARD_USER_CFG = os.path.join(
     os.environ["APPDATA"], "Skyline", "PhotoMesh", "Wizard", "config.json"
 )
 
-# Installed Wizard config (official path per manual)
-WIZARD_DIR = r"C:\Program Files\Skyline\PhotoMesh\Tools\PhotomeshWizard"
-WIZARD_INSTALL_CFG = rf"{WIZARD_DIR}\config.json"
+# Detect installed Wizard directory / executable
 
 
-def _find_wizard_exe():
+def _detect_wizard_dir() -> str:
+    candidates = [
+        r"C:\\Program Files\\Skyline\\PhotoMeshWizard",                 # NEW preferred
+        r"C:\\Program Files\\Skyline\\PhotoMesh\\Tools\\PhotomeshWizard", # legacy
+    ]
+    for d in candidates:
+        if os.path.isdir(d):
+            return d
+    # last-resort scan
+    for dp, _dn, files in os.walk(r"C:\\Program Files\\Skyline"):
+        if "PhotoMeshWizard.exe" in files or "WizardGUI.exe" in files:
+            return dp
+    raise FileNotFoundError("PhotoMesh Wizard folder not found")
+
+
+WIZARD_DIR = _detect_wizard_dir()
+WIZARD_INSTALL_CFG = os.path.join(WIZARD_DIR, "config.json")
+
+
+def _find_wizard_exe() -> str:
     for exe in ("PhotoMeshWizard.exe", "WizardGUI.exe"):
         p = os.path.join(WIZARD_DIR, exe)
         if os.path.isfile(p):
             return p
-    raise FileNotFoundError("PhotoMesh Wizard executable not found.")
+    raise FileNotFoundError("PhotoMesh Wizard executable not found")
 
 
-# PhotoMesh Wizard executable
 WIZARD_EXE = _find_wizard_exe()
 
 # Preset configuration
@@ -413,7 +429,7 @@ def launch_wizard_cli(project_name: str, project_path: str, folders: List[str]) 
         args += ["--folder", fld]
 
     try:
-        subprocess.Popen(args, cwd=os.path.dirname(WIZARD_EXE))
+        subprocess.Popen(args, cwd=WIZARD_DIR)
     except Exception as e:
         from tkinter import messagebox
 
@@ -517,7 +533,7 @@ def launch_photomesh_with_preset(project_name: str, project_path: str, image_fol
     creationflags = getattr(subprocess, "CREATE_NO_WINDOW", 0)
     try:
         return subprocess.Popen(
-            args, cwd=os.path.dirname(WIZARD_EXE), creationflags=creationflags
+            args, cwd=WIZARD_DIR, creationflags=creationflags
         )
     except Exception as exc:
         print(f"Failed to launch PhotoMeshWizard: {exc}")

--- a/PythonPorjects/photomesh/bootstrap.py
+++ b/PythonPorjects/photomesh/bootstrap.py
@@ -43,8 +43,8 @@ def detect_wizard_dir(pm_dir: str) -> str:
     """Return the directory containing ``PhotoMeshWizard.exe``."""
 
     cands = [
-        os.path.join(pm_dir, r"Tools\PhotomeshWizard"),
         r"C:\\Program Files\\Skyline\\PhotoMeshWizard",
+        os.path.join(pm_dir, r"Tools\\PhotomeshWizard"),
     ]
     for d in cands:
         if os.path.isdir(d):


### PR DESCRIPTION
## Summary
- detect the new `PhotoMeshWizard` install location and fall back to the legacy folder
- update OBJ-only configuration writer to touch both possible install-level config.json files
- launch PhotoMesh Wizard using the detected directory

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b21c3062848322b455bc4bad8efcfb

## Summary by Sourcery

Prefer the new PhotoMeshWizard installation path by detecting it at runtime and falling back to the legacy path, update the configuration writer to modify all potential config.json locations, and unify the launch process to use the detected directory.

New Features:
- Detect PhotoMeshWizard in the new install location with fallback to the legacy folder
- Launch PhotoMeshWizard using the dynamically detected installation directory

Enhancements:
- Update the OBJ-only configuration writer to update both new and legacy install-level config.json files
- Consolidate and extend config updates in enable_obj_in_photomesh_config, including OutputProducts and UI settings
- Add directory scanning as a last-resort method to locate the Wizard folder
- Refactor launch logic and path resolution to use a unified WIZARD_DIR variable