### PR TITLE
feat: enforce wizard config with UNC

### DIFF
--- a/PythonPorjects/STE_Toolkit.py
+++ b/PythonPorjects/STE_Toolkit.py
@@ -3428,6 +3428,14 @@ class VBS4Panel(tk.Frame):
 
         self.log_message(f"Creating mesh for project: {project_name}")
 
+        # Determine the fuser UNC (prefer Offline cfg, else use host from config, else default)
+        try:
+            host = config.get("Offline", "working_fuser_host", fallback="KIT1-1").strip()
+        except Exception:
+            host = "KIT1-1"
+        fuser_unc = rf"\\{host}\SharedMeshDrive\WorkingFuser"
+
+        # Optional: your standard preset name (or None if not using one)
         preset_name = "OECPP"
 
         try:
@@ -3436,6 +3444,9 @@ class VBS4Panel(tk.Frame):
                 project_path,
                 self.image_folder_paths,
                 preset=preset_name,
+                autostart=True,
+                fuser_unc=fuser_unc,
+                log=self.log_message,
             )
             self.log_message("PhotoMesh Wizard launched with --autostart.")
             if hasattr(self, "detach_wizard_on_photomesh_start_by_pid"):

--- a/PythonPorjects/photomesh/launch_photomesh_preset.py
+++ b/PythonPorjects/photomesh/launch_photomesh_preset.py
@@ -3,46 +3,120 @@
 from __future__ import annotations
 
 import os
+import json
 import subprocess
 
 from .bootstrap import stage_install_preset
 
 
 def _detect_wizard_dir() -> str:
-    """Return the directory containing ``PhotoMeshWizard.exe``."""
-
-    cands = [
-        r"C:\\Program Files\\Skyline\\PhotoMeshWizard",
-        r"C:\\Program Files\\Skyline\\PhotoMesh\\Tools\\PhotomeshWizard",
+    candidates = [
+        r"C:\\Program Files\\Skyline\\PhotoMeshWizard",                 # NEW preferred
+        r"C:\\Program Files\\Skyline\\PhotoMesh\\Tools\\PhotomeshWizard", # legacy
     ]
-    for d in cands:
+    for d in candidates:
         if os.path.isdir(d):
             return d
-    for dp, _, fs in os.walk(r"C:\\Program Files\\Skyline"):
-        if "PhotoMeshWizard.exe" in fs or "WizardGUI.exe" in fs:
+    for dp, _dn, files in os.walk(r"C:\\Program Files\\Skyline"):
+        if "PhotoMeshWizard.exe" in files or "WizardGUI.exe" in files:
             return dp
-    raise FileNotFoundError("Wizard not found")
-
-
-def _find_wizard_exe(d: str) -> str:
-    """Return the best wizard executable path in *d*."""
-
-    for name in ("PhotoMeshWizard.exe", "WizardGUI.exe"):
-        p = os.path.join(d, name)
-        if os.path.isfile(p):
-            return p
-    raise FileNotFoundError("Wizard executable not found")
+    raise FileNotFoundError("PhotoMesh Wizard folder not found")
 
 
 try:  # pragma: no cover - environment specific
     WIZARD_DIR = _detect_wizard_dir()
 except FileNotFoundError:  # pragma: no cover - missing install
     WIZARD_DIR = r"C:\\Program Files\\Skyline\\PhotoMeshWizard"
+WIZARD_INSTALL_CFG = os.path.join(WIZARD_DIR, "config.json")
+
+
+def _find_wizard_exe() -> str:
+    for exe in ("PhotoMeshWizard.exe", "WizardGUI.exe"):
+        p = os.path.join(WIZARD_DIR, exe)
+        if os.path.isfile(p):
+            return p
+    raise FileNotFoundError("PhotoMesh Wizard executable not found")
+
 
 try:  # pragma: no cover - environment specific
-    WIZARD_EXE = _find_wizard_exe(WIZARD_DIR)
+    WIZARD_EXE = _find_wizard_exe()
 except FileNotFoundError:  # pragma: no cover - missing install
     WIZARD_EXE = os.path.join(WIZARD_DIR, "PhotoMeshWizard.exe")
+
+
+def _load_json_safe(path: str) -> dict:
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            return json.load(f)
+    except Exception:
+        return {}
+
+
+def _save_json_safe(path: str, data: dict) -> None:
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    tmp = path + ".tmp"
+    with open(tmp, "w", encoding="utf-8") as f:
+        json.dump(data, f, indent=2)
+    os.replace(tmp, path)
+
+
+def enforce_wizard_install_config(
+    *, obj: bool = True, ortho: bool = True, fuser_unc: str | None = None, log=print
+):
+    """
+    Write C:\Program Files\Skyline\PhotoMeshWizard\config.json (or legacy) so:
+      - OutputProducts: 3D Model ON, Ortho ON (Wizard-only requirement)
+      - Model3DFormats: OBJ=True, 3DML=False
+      - CenterPivot/ReprojectEllipsoid = True
+      - NetworkWorkingFolder = fuser UNC (param or Offline cfg)
+      - UseMinimize=True, ClosePMWhenDone=True
+    """
+
+    cfg = _load_json_safe(WIZARD_INSTALL_CFG)
+
+    ui = cfg.setdefault("DefaultPhotoMeshWizardUI", {})
+    outs = ui.setdefault("OutputProducts", {})
+    # Support both key spellings (seen in the wild)
+    outs["3DModel"] = True
+    outs["Model3D"] = True
+    outs["Ortho"] = bool(ortho)
+
+    m3d = ui.setdefault("Model3DFormats", {})
+    # turn all boolean formats off then explicitly enable OBJ only
+    for k, v in list(m3d.items()):
+        if isinstance(v, bool):
+            m3d[k] = False
+    m3d["OBJ"] = bool(obj)
+    m3d["3DML"] = False
+
+    # Pivot/Ellipsoid flags used by downstream step
+    ui["CenterPivotToProject"] = True
+    ui["CenterModelsToProject"] = True
+    ui["ReprojectToEllipsoid"] = True
+
+    # UX niceties
+    cfg["UseMinimize"] = True
+    cfg["ClosePMWhenDone"] = True
+
+    # Fuser working UNC
+    if fuser_unc is None:
+        try:
+            # If you already have these helpers in your project, they’ll resolve from Offline settings:
+            from .bootstrap import get_offline_cfg, resolve_network_working_folder_from_cfg
+
+            fuser_unc = resolve_network_working_folder_from_cfg(get_offline_cfg())
+        except Exception:
+            # Default if Offline cfg is not available
+            fuser_unc = r"\\KIT1-1\SharedMeshDrive\WorkingFuser"
+    cfg["NetworkWorkingFolder"] = fuser_unc
+
+    _save_json_safe(WIZARD_INSTALL_CFG, cfg)
+    log(
+        f"✅ Wizard config updated: {WIZARD_INSTALL_CFG}\n"
+        f"   - 3DModel=True, Ortho={outs['Ortho']}\n"
+        f"   - OBJ={m3d.get('OBJ')}, 3DML={m3d.get('3DML')}\n"
+        f"   - NetworkWorkingFolder={cfg['NetworkWorkingFolder']}"
+    )
 
 
 def launch_wizard_with_preset(
@@ -50,9 +124,20 @@ def launch_wizard_with_preset(
     project_path: str,
     imagery_folders: list[str] | None,
     preset: str | None = None,
-    extra_args: list[str] | None = None,
+    *,
+    autostart: bool = True,
+    fuser_unc: str | None = None,
+    log=print,
 ) -> subprocess.Popen:
-    """Launch PhotoMesh Wizard and autostart the build with our preset."""
+    """Launch PhotoMesh Wizard and optionally autostart the build with our preset."""
+
+    # Write install-level config so the Wizard starts with correct UI flags & fuser UNC
+    try:
+        enforce_wizard_install_config(obj=True, ortho=True, fuser_unc=fuser_unc, log=log)
+    except PermissionError:
+        log(
+            "⚠️ No permission to write install-level config.json (run as Admin or pre-stage). Continuing."
+        )
 
     args = [
         WIZARD_EXE,
@@ -61,16 +146,14 @@ def launch_wizard_with_preset(
         "--projectPath",
         project_path,
         "--overrideSettings",
-        "--autostart",
     ]
     if preset:
         args += ["--preset", preset]
+    if autostart:
+        args += ["--autostart"]
 
     for f in imagery_folders or []:
         args += ["--folder", f]
-
-    if extra_args:
-        args += extra_args
 
     creationflags = getattr(subprocess, "CREATE_NO_WINDOW", 0)
     return subprocess.Popen(args, cwd=WIZARD_DIR, creationflags=creationflags)
@@ -91,5 +174,9 @@ def launch_photomesh_with_install_preset(
     )
 
 
-__all__ = ["launch_wizard_with_preset", "launch_photomesh_with_install_preset"]
+__all__ = [
+    "launch_wizard_with_preset",
+    "launch_photomesh_with_install_preset",
+    "enforce_wizard_install_config",
+]
 

--- a/tests/test_launch_photomesh_wrapper.py
+++ b/tests/test_launch_photomesh_wrapper.py
@@ -28,6 +28,10 @@ def test_launch_wizard_with_preset(monkeypatch):
     monkeypatch.setattr(
         "photomesh.launch_photomesh_preset.WIZARD_DIR", "wizdir"
     )
+    monkeypatch.setattr(
+        "photomesh.launch_photomesh_preset.enforce_wizard_install_config",
+        lambda **kwargs: None,
+    )
 
     launch_wizard_with_preset("proj", "path", ["a", "b"], preset="Preset")
 
@@ -39,9 +43,9 @@ def test_launch_wizard_with_preset(monkeypatch):
         "--projectPath",
         "path",
         "--overrideSettings",
-        "--autostart",
         "--preset",
         "Preset",
+        "--autostart",
         "--folder",
         "a",
         "--folder",


### PR DESCRIPTION
## Summary
- extend PhotoMesh Wizard launcher to enforce install-level config and support UNC-based fuser paths
- forward network working folder and autostart flag when launching the wizard from toolkit
- adjust tests for new launch order and config enforcement

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b6f68b9e6c8322a51029f50d8b252d

## Summary by Sourcery

Enforce install-level wizard configuration and support UNC-based fuser paths when launching PhotoMesh Wizard from the toolkit.

New Features:
- Add enforce_wizard_install_config to write required UI defaults and network UNC settings to install config JSON
- Support autostart and fuser_unc parameters in launch_wizard_with_preset and forward them from STE_Toolkit

Enhancements:
- Refactor wizard directory and executable detection to simplify path resolution
- Introduce safe JSON load/save helpers for configuration management

Tests:
- Stub out enforce_wizard_install_config in tests and update expected launch arguments order to include autostart