### PR TITLE
Enforce PhotoMesh Wizard config and auto-start builds

### DIFF
--- a/PythonPorjects/STE_Toolkit.py
+++ b/PythonPorjects/STE_Toolkit.py
@@ -3428,6 +3428,12 @@ class VBS4Panel(tk.Frame):
 
         self.log_message(f"Creating mesh for project: {project_name}")
 
+        try:
+            host = config.get("Offline", "working_fuser_host", fallback="KIT1-1").strip()
+        except Exception:
+            host = "KIT1-1"
+        fuser_unc = rf"\\{host}\SharedMeshDrive\WorkingFuser"
+
         preset_name = "OECPP"
 
         try:
@@ -3436,6 +3442,9 @@ class VBS4Panel(tk.Frame):
                 project_path,
                 self.image_folder_paths,
                 preset=preset_name,
+                autostart=True,
+                fuser_unc=fuser_unc,
+                log=self.log_message,
             )
             self.log_message("PhotoMesh Wizard launched with --autostart.")
             if hasattr(self, "detach_wizard_on_photomesh_start_by_pid"):

--- a/PythonPorjects/photomesh/launch_photomesh_preset.py
+++ b/PythonPorjects/photomesh/launch_photomesh_preset.py
@@ -2,36 +2,23 @@
 
 from __future__ import annotations
 
-import os
-import subprocess
+import os, json, subprocess
 
 from .bootstrap import stage_install_preset
 
 
 def _detect_wizard_dir() -> str:
-    """Return the directory containing ``PhotoMeshWizard.exe``."""
-
-    cands = [
+    candidates = [
         r"C:\\Program Files\\Skyline\\PhotoMeshWizard",
         r"C:\\Program Files\\Skyline\\PhotoMesh\\Tools\\PhotomeshWizard",
     ]
-    for d in cands:
+    for d in candidates:
         if os.path.isdir(d):
             return d
-    for dp, _, fs in os.walk(r"C:\\Program Files\\Skyline"):
-        if "PhotoMeshWizard.exe" in fs or "WizardGUI.exe" in fs:
+    for dp, _dn, files in os.walk(r"C:\\Program Files\\Skyline"):
+        if "PhotoMeshWizard.exe" in files or "WizardGUI.exe" in files:
             return dp
-    raise FileNotFoundError("Wizard not found")
-
-
-def _find_wizard_exe(d: str) -> str:
-    """Return the best wizard executable path in *d*."""
-
-    for name in ("PhotoMeshWizard.exe", "WizardGUI.exe"):
-        p = os.path.join(d, name)
-        if os.path.isfile(p):
-            return p
-    raise FileNotFoundError("Wizard executable not found")
+    raise FileNotFoundError("PhotoMesh Wizard folder not found")
 
 
 try:  # pragma: no cover - environment specific
@@ -39,20 +26,105 @@ try:  # pragma: no cover - environment specific
 except FileNotFoundError:  # pragma: no cover - missing install
     WIZARD_DIR = r"C:\\Program Files\\Skyline\\PhotoMeshWizard"
 
+WIZARD_INSTALL_CFG = os.path.join(WIZARD_DIR, "config.json")
+
+
+def _find_wizard_exe() -> str:
+    for exe in ("PhotoMeshWizard.exe", "WizardGUI.exe"):
+        p = os.path.join(WIZARD_DIR, exe)
+        if os.path.isfile(p):
+            return p
+    raise FileNotFoundError("PhotoMesh Wizard executable not found")
+
+
 try:  # pragma: no cover - environment specific
-    WIZARD_EXE = _find_wizard_exe(WIZARD_DIR)
+    WIZARD_EXE = _find_wizard_exe()
 except FileNotFoundError:  # pragma: no cover - missing install
     WIZARD_EXE = os.path.join(WIZARD_DIR, "PhotoMeshWizard.exe")
+
+
+def _load_json_safe(path: str) -> dict:
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            return json.load(f)
+    except Exception:
+        return {}
+
+
+def _save_json_safe(path: str, data: dict) -> None:
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    tmp = path + ".tmp"
+    with open(tmp, "w", encoding="utf-8") as f:
+        json.dump(data, f, indent=2)
+    os.replace(tmp, path)
+
+
+def enforce_wizard_install_config(*, obj: bool = True, ortho: bool = True,
+                                  fuser_unc: str | None = None, log=print):
+    """
+    Write C:\\Program Files\\Skyline\\PhotoMeshWizard\\config.json (or legacy) so:
+      - OutputProducts: 3D Model ON, Ortho ON (Wizard-only requirement)
+      - Model3DFormats: OBJ=True, 3DML=False
+      - CenterPivot/ReprojectEllipsoid = True
+      - NetworkWorkingFolder = fuser UNC (param or Offline cfg)
+      - UseMinimize=True, ClosePMWhenDone=True
+    """
+    cfg = _load_json_safe(WIZARD_INSTALL_CFG)
+
+    ui = cfg.setdefault("DefaultPhotoMeshWizardUI", {})
+    outs = ui.setdefault("OutputProducts", {})
+    outs["3DModel"] = True
+    outs["Model3D"] = True
+    outs["Ortho"] = bool(ortho)
+
+    m3d = ui.setdefault("Model3DFormats", {})
+    for k, v in list(m3d.items()):
+        if isinstance(v, bool):
+            m3d[k] = False
+    m3d["OBJ"] = bool(obj)
+    m3d["3DML"] = False
+
+    ui["CenterPivotToProject"] = True
+    ui["CenterModelsToProject"] = True
+    ui["ReprojectToEllipsoid"] = True
+
+    cfg["UseMinimize"] = True
+    cfg["ClosePMWhenDone"] = True
+
+    if fuser_unc is None:
+        try:
+            from .bootstrap import get_offline_cfg, resolve_network_working_folder_from_cfg
+            fuser_unc = resolve_network_working_folder_from_cfg(get_offline_cfg())
+        except Exception:
+            fuser_unc = r"\\KIT1-1\SharedMeshDrive\WorkingFuser"
+    cfg["NetworkWorkingFolder"] = fuser_unc
+
+    _save_json_safe(WIZARD_INSTALL_CFG, cfg)
+    log(
+        f"✅ Wizard config updated: {WIZARD_INSTALL_CFG}\n"
+        f"   - 3DModel=True, Ortho={outs['Ortho']}\n"
+        f"   - OBJ={m3d.get('OBJ')}, 3DML={m3d.get('3DML')}\n"
+        f"   - NetworkWorkingFolder={cfg['NetworkWorkingFolder']}"
+    )
 
 
 def launch_wizard_with_preset(
     project_name: str,
     project_path: str,
-    imagery_folders: list[str] | None,
+    imagery_folders: list[str],
     preset: str | None = None,
-    extra_args: list[str] | None = None,
+    *,
+    autostart: bool = True,
+    fuser_unc: str | None = None,
+    log=print,
 ) -> subprocess.Popen:
-    """Launch PhotoMesh Wizard and autostart the build with our preset."""
+    # Write install-level config so the Wizard starts with correct UI flags & fuser UNC
+    try:
+        enforce_wizard_install_config(obj=True, ortho=True, fuser_unc=fuser_unc, log=log)
+    except PermissionError:
+        log(
+            "⚠️ No permission to write install-level config.json (run as Admin or pre-stage). Continuing."
+        )
 
     args = [
         WIZARD_EXE,
@@ -61,16 +133,14 @@ def launch_wizard_with_preset(
         "--projectPath",
         project_path,
         "--overrideSettings",
-        "--autostart",
     ]
     if preset:
         args += ["--preset", preset]
+    if autostart:
+        args += ["--autostart"]
 
     for f in imagery_folders or []:
         args += ["--folder", f]
-
-    if extra_args:
-        args += extra_args
 
     creationflags = getattr(subprocess, "CREATE_NO_WINDOW", 0)
     return subprocess.Popen(args, cwd=WIZARD_DIR, creationflags=creationflags)

--- a/tests/test_launch_photomesh_wrapper.py
+++ b/tests/test_launch_photomesh_wrapper.py
@@ -28,6 +28,10 @@ def test_launch_wizard_with_preset(monkeypatch):
     monkeypatch.setattr(
         "photomesh.launch_photomesh_preset.WIZARD_DIR", "wizdir"
     )
+    monkeypatch.setattr(
+        "photomesh.launch_photomesh_preset.enforce_wizard_install_config",
+        lambda **kwargs: None,
+    )
 
     launch_wizard_with_preset("proj", "path", ["a", "b"], preset="Preset")
 
@@ -39,9 +43,9 @@ def test_launch_wizard_with_preset(monkeypatch):
         "--projectPath",
         "path",
         "--overrideSettings",
-        "--autostart",
         "--preset",
         "Preset",
+        "--autostart",
         "--folder",
         "a",
         "--folder",
@@ -55,8 +59,8 @@ def test_launch_photomesh_with_install_preset(monkeypatch):
     def fake_stage(repo_preset_path, preset_name):
         calls["stage"] = (repo_preset_path, preset_name)
 
-    def fake_launch(project_name, project_path, folders, preset=None, extra_args=None):
-        calls["launch"] = (project_name, project_path, tuple(folders), preset)
+    def fake_launch(project_name, project_path, folders, preset=None, *, autostart=True, fuser_unc=None, log=print):
+        calls["launch"] = (project_name, project_path, tuple(folders), preset, autostart, fuser_unc)
 
     monkeypatch.setattr(
         "photomesh.launch_photomesh_preset.stage_install_preset", fake_stage
@@ -71,5 +75,5 @@ def test_launch_photomesh_with_install_preset(monkeypatch):
     )
 
     assert calls["stage"] == ("repo.preset", "Preset")
-    assert calls["launch"] == ("proj", "path", ("a", "b"), "Preset")
+    assert calls["launch"] == ("proj", "path", ("a", "b"), "Preset", True, None)
 


### PR DESCRIPTION
## Summary
- Prefer `C:\Program Files\Skyline\PhotoMeshWizard` for Wizard lookup and add helpers for reading/writing install-level `config.json`
- Provide `enforce_wizard_install_config` to force output products, OBJ/3DML flags, and UNC NetworkWorkingFolder
- Update launcher to call config enforcer, support `--autostart`, and pass working UNC from `STE_Toolkit`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b6f68b9e6c8322a51029f50d8b252d

## Summary by Sourcery

Enforce PhotoMesh Wizard install configuration and enable auto-start builds by injecting a config-enforcing function into the launch process, extending launch_wizard_with_preset with autostart and network working folder parameters, and updating tests and STE_Toolkit integration accordingly.

New Features:
- Add enforce_wizard_install_config to write install-level config.json with required output settings, model formats, and network working folder
- Support autostart and fuser_unc parameters in launch_wizard_with_preset and conditionally include the --autostart flag
- Propagate network working folder from STE_Toolkit.create_mesh into launch_wizard_with_preset for automated builds

Enhancements:
- Refactor wizard directory and executable detection into unified helpers
- Introduce safe JSON load/save helpers for config.json operations

Tests:
- Update tests to stub enforce_wizard_install_config and validate new autostart and fuser_unc argument handling