### PR TITLE
Add robust preset handling for PhotoMesh

### DIFF
--- a/PythonPorjects/STE_Toolkit.py
+++ b/PythonPorjects/STE_Toolkit.py
@@ -22,8 +22,6 @@ try:
 except Exception:  # pragma: no cover - psutil may not be installed
     psutil = None
 from photomesh_launcher import (
-    stage_install_preset,
-    enforce_wizard_install_config,
     launch_wizard_with_preset,
     get_offline_cfg,
     ensure_offline_share_exists,
@@ -2604,6 +2602,14 @@ class VBS4Panel(tk.Frame):
         enable_obj_in_photomesh_config()
         set_active_wizard_preset()
 
+        self.preset_entry = tk.Entry(self, width=30)
+        try:
+            default_preset = config.get("PhotoMeshAPI", "preset", fallback="OECPP")
+        except Exception:
+            default_preset = "OECPP"
+        self.preset_entry.insert(0, default_preset)
+        self.preset_entry.pack()
+
         tk.Label(
             self,
             text="VBS4 / BlueIG",
@@ -3433,20 +3439,14 @@ class VBS4Panel(tk.Frame):
         except Exception:
             host = "KIT1-1"
         fuser_unc = rf"\\{host}\SharedMeshDrive\WorkingFuser"
-        preset_name = "OECPP"
-        repo_preset = os.path.join(
-            os.path.dirname(__file__), "photomesh", "OECPP.PMPreset"
-        )
-
-        stage_install_preset(repo_preset, preset_name)
-        enforce_wizard_install_config(ortho_ui=True)
+        desired = self.preset_entry.get().strip() or "OECPP"
 
         try:
             proc = launch_wizard_with_preset(
                 project_name,
                 project_path,
                 self.image_folder_paths,
-                preset=preset_name,
+                preset=desired,
                 autostart=True,
                 fuser_unc=fuser_unc,
                 log=self.log_message,

--- a/PythonPorjects/config.json
+++ b/PythonPorjects/config.json
@@ -1,0 +1,10 @@
+{
+  "PhotoMeshAPI": {
+    "queue_base_url": "http://localhost:8087/ProjectQueue",
+    "sse_url": "http://localhost:8087/ProjectQueue/events",
+    "preset": "OECPP",
+    "enforce_obj_only": true,
+    "working_fuser_unc": "\\\\KIT1-1\\SharedMeshDrive\\WorkingFuser",
+    "max_local_fusers": 4
+  }
+}

--- a/PythonPorjects/photomesh_launcher.py
+++ b/PythonPorjects/photomesh_launcher.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 import os, json, shutil, subprocess, tempfile, configparser
 from typing import Iterable, Optional
 
+from photomesh_preset import stage_preset
+
 try:  # pragma: no cover - tkinter may not be available
     from tkinter import messagebox
 except Exception:  # pragma: no cover - headless/test environments
@@ -425,7 +427,7 @@ def launch_wizard_with_preset(
         "--overrideSettings",
     ]
     if preset:
-        norm = _preset_arg_from_user_value(preset)
+        norm = stage_preset(preset, enforce_obj_only=False, log=log)
         if norm:
             args += ["--preset", norm]
     if autostart:

--- a/PythonPorjects/photomesh_preset.py
+++ b/PythonPorjects/photomesh_preset.py
@@ -1,0 +1,84 @@
+import os
+import shutil
+import logging
+import xml.etree.ElementTree as ET
+
+LOG = logging.getLogger("pm_preset")
+
+APPDATA_PRESETS = os.path.join(os.environ.get("APPDATA", ""), r"Skyline\PhotoMesh\Presets")
+INSTALL_PRESETS = r"C:\\Program Files\\Skyline\\PhotoMesh\\Presets"
+
+
+def _ensure_dirs() -> None:
+    os.makedirs(APPDATA_PRESETS, exist_ok=True)
+    try:
+        os.makedirs(INSTALL_PRESETS, exist_ok=True)
+    except PermissionError:
+        pass
+
+
+def _normalize_to_name_only(preset: str) -> str:
+    """Return the bare preset name (no extension, no path)."""
+    v = (preset or "").strip().strip('"').strip("'")
+    base = os.path.basename(v)
+    name, _ext = os.path.splitext(base)
+    return name if name else v
+
+
+def _maybe_normalize_xml(preset_path: str, enforce_obj_only: bool, log=LOG.info) -> None:
+    if not enforce_obj_only:
+        return
+    try:
+        arr = "http://schemas.microsoft.com/2003/10/Serialization/Arrays"
+        ET.register_namespace("d3p1", arr)
+        tree = ET.parse(preset_path)
+        root = tree.getroot()
+        bp = root.find("./BuildParameters") or ET.SubElement(root, "BuildParameters")
+
+        ofs = bp.find("OutputFormats") or ET.SubElement(bp, "OutputFormats")
+        for c in list(ofs):
+            ofs.remove(c)
+        ET.SubElement(ofs, f"{{{arr}}}string").text = "OBJ"
+
+        (bp.find("CenterModelsToProject") or ET.SubElement(bp, "CenterModelsToProject")).text = "true"
+        (bp.find("CesiumReprojectZ") or ET.SubElement(bp, "CesiumReprojectZ")).text = "true"
+
+        for tag in ("IsDefault", "IsLastUsed"):
+            (root.find(tag) or ET.SubElement(root, tag)).text = "true"
+
+        tree.write(preset_path, encoding="utf-8", xml_declaration=True)
+        log(f"[preset] normalized to OBJ-only + center/ellipsoid: {preset_path}")
+    except Exception as e:  # pragma: no cover - best effort
+        log(f"⚠️ preset normalization skipped ({e})")
+
+
+def stage_preset(preset_input: str, enforce_obj_only: bool = False, log=LOG.info) -> str:
+    """
+    Accepts either a preset NAME (e.g. 'OECPP') or a .PMPreset FILE path.
+    If a path is given, copies it into a Presets folder and returns the NAME-ONLY.
+    If a name is given, just returns the cleaned name (assumes it exists in a Presets folder).
+    """
+    _ensure_dirs()
+    if not preset_input:
+        raise ValueError("preset_input is empty")
+
+    if os.path.isfile(preset_input):
+        name = _normalize_to_name_only(preset_input)
+        dest_pf = os.path.join(INSTALL_PRESETS, f"{name}.PMPreset")
+        dest_ad = os.path.join(APPDATA_PRESETS, f"{name}.PMPreset")
+        try:
+            shutil.copy2(preset_input, dest_pf)
+            preset_path = dest_pf
+            log(f"[preset] staged to Program Files: {preset_path}")
+        except PermissionError:
+            shutil.copy2(preset_input, dest_ad)
+            preset_path = dest_ad
+            log(f"[preset] staged to AppData: {preset_path}")
+
+        _maybe_normalize_xml(preset_path, enforce_obj_only, log)
+        return name
+
+    name_only = _normalize_to_name_only(preset_input)
+    return name_only
+
+__all__ = ["stage_preset"]

--- a/PythonPorjects/photomesh_rest.py
+++ b/PythonPorjects/photomesh_rest.py
@@ -1,0 +1,50 @@
+import os
+from typing import Iterable
+
+from photomesh_preset import stage_preset
+
+
+def build_queue_payload(
+    project_name: str,
+    project_path: str,
+    image_folders: Iterable[str],
+    config,
+    preset_name: str | None = None,
+) -> list[dict]:
+    api = config.get("PhotoMeshAPI", {})
+    desired = (preset_name or api.get("preset") or "OECPP").strip()
+    enforce_obj_only = bool(api.get("enforce_obj_only", True))
+    preset_name_only = stage_preset(desired, enforce_obj_only=enforce_obj_only)
+
+    working = api.get("working_fuser_unc", "")
+    max_local = int(api.get("max_local_fusers", 4))
+
+    src: list[dict] = []
+    for f in image_folders:
+        if f and os.path.isdir(f):
+            src.append({"name": os.path.basename(f), "path": f, "properties": ""})
+    if not src:
+        raise ValueError("No valid imagery folders")
+
+    return [
+        {
+            "comment": f"{project_name}",
+            "action": 0,
+            "projectPath": project_path,
+            "buildFrom": 1,
+            "buildUntil": 6,
+            "inheritBuild": "",
+            "preset": preset_name_only,
+            "workingFolder": working,
+            "MaxLocalFusers": max_local,
+            "MaxAWSFusers": 0,
+            "AWSFuserStartupScript": "",
+            "AWSBuildConfigurationName": "",
+            "AWSBuildConfigurationJsonPath": "",
+            "sourceType": 0,
+            "sourcePath": src,
+        }
+    ]
+
+
+__all__ = ["build_queue_payload"]

--- a/tests/test_launch_photomesh_wrapper.py
+++ b/tests/test_launch_photomesh_wrapper.py
@@ -34,6 +34,10 @@ def test_launch_wizard_with_preset(monkeypatch):
         "photomesh_launcher.enforce_wizard_install_config",
         lambda **kwargs: None,
     )
+    monkeypatch.setattr(
+        "photomesh_launcher.stage_preset",
+        lambda preset, enforce_obj_only=False, log=None: preset,
+    )
 
     launch_wizard_with_preset("proj", "path", ["a", "b"], preset="Preset")
 


### PR DESCRIPTION
## Summary
- support preset staging via new `photomesh_preset.stage_preset`
- integrate staged preset name into REST payloads and Wizard launches
- allow GUI users to choose preset name or file

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b72d6353808322b60b7bc9455fe974