### PR TITLE
Hard-code PhotoMesh preset

### DIFF
--- a/PythonPorjects/STE_Toolkit.py
+++ b/PythonPorjects/STE_Toolkit.py
@@ -21,8 +21,10 @@ try:
     import psutil
 except Exception:  # pragma: no cover - psutil may not be installed
     psutil = None
+from photomesh_preset import stage_preset
 from photomesh_launcher import (
-    launch_wizard_with_preset,
+    enforce_wizard_defaults_obj_only,
+    launch_autostart_build,
     get_offline_cfg,
     ensure_offline_share_exists,
     can_access_unc,
@@ -3435,23 +3437,28 @@ class VBS4Panel(tk.Frame):
         self.log_message(f"Creating mesh for project: {project_name}")
 
         try:
-            host = config.get("Offline", "working_fuser_host", fallback="KIT1-1").strip()
+            host = config.get("Offline", "working_fuser_host", fallback="KIT1-1").strip() or "KIT1-1"
         except Exception:
             host = "KIT1-1"
         fuser_unc = rf"\\{host}\SharedMeshDrive\WorkingFuser"
-        desired = self.preset_entry.get().strip() or "OECPP"
+
+        # Hard-coded preset (same value used in watcher)
+        PRESET_INPUT = r"C:\Users\tifte\Documents\GitHub\VBS4Project\PythonPorjects\photomesh\OECPP.PMPreset"
+        PRESET_NAME = stage_preset(PRESET_INPUT, enforce_obj_only=True)
 
         try:
-            proc = launch_wizard_with_preset(
+            # Enforce Wizard JSON defaults: 3DModel ON, Ortho OFF, OBJ ON, 3DML OFF, pivot+ellipsoid ON
+            enforce_wizard_defaults_obj_only(fuser_unc=fuser_unc, log=self.log_message)
+
+            # Launch Wizard with --overrideSettings --autostart --preset <NAME ONLY>
+            proc = launch_autostart_build(
                 project_name,
                 project_path,
                 self.image_folder_paths,
-                preset=desired,
-                autostart=True,
-                fuser_unc=fuser_unc,
+                preset_name=PRESET_NAME,
                 log=self.log_message,
             )
-            self.log_message("PhotoMesh Wizard launched with --autostart.")
+            self.log_message(f"PhotoMesh Wizard launched with preset '{PRESET_NAME}' (autostart).")
             if hasattr(self, "detach_wizard_on_photomesh_start_by_pid"):
                 self.detach_wizard_on_photomesh_start_by_pid(proc.pid, project_path)
             self.start_progress_monitor(project_path)

--- a/PythonPorjects/photomesh_launcher.py
+++ b/PythonPorjects/photomesh_launcher.py
@@ -397,6 +397,49 @@ def enforce_photomesh_settings(preset: str = "", autostart: bool = True) -> None
     enforce_wizard_install_config(fuser_unc=fuser_unc)
     ensure_wizard_user_defaults(preset=preset, autostart=autostart)
 
+# -------------------- OBJ-only defaults + autostart launch --------------------
+def enforce_wizard_defaults_obj_only(
+    *, fuser_unc: Optional[str] = None, log=print
+) -> None:
+    """Enforce install config for OBJ-only build (Ortho OFF, OBJ ON)."""
+    enforce_wizard_install_config(
+        model3d=True,
+        obj=True,
+        d3dml=False,
+        ortho_ui=False,
+        center_pivot=True,
+        ellipsoid=True,
+        fuser_unc=fuser_unc,
+        log=log,
+    )
+
+
+def launch_autostart_build(
+    project_name: str,
+    project_path: str,
+    imagery_folders: Iterable[str],
+    *,
+    preset_name: str = "",
+    log=print,
+) -> subprocess.Popen:
+    """Launch PhotoMesh Wizard with --overrideSettings --autostart and optional --preset."""
+    args = [
+        WIZARD_EXE,
+        "--projectName",
+        project_name,
+        "--projectPath",
+        project_path,
+        "--overrideSettings",
+        "--autostart",
+    ]
+    if preset_name:
+        args += ["--preset", preset_name]
+    for folder in imagery_folders or []:
+        args += ["--folder", folder]
+
+    creationflags = getattr(subprocess, "CREATE_NO_WINDOW", 0)
+    return subprocess.Popen(args, cwd=WIZARD_DIR, creationflags=creationflags)
+
 # -------------------- Launch Wizard with preset --------------------
 def launch_wizard_with_preset(
     project_name: str,

--- a/PythonPorjects/photomesh_rest.py
+++ b/PythonPorjects/photomesh_rest.py
@@ -3,19 +3,21 @@ from typing import Iterable
 
 from photomesh_preset import stage_preset
 
+# === Preset (hard-coded) ===
+# Use either a preset name ("OECPP") or a full .PMPreset path from the repo.
+PRESET_INPUT = r"C:\Users\tifte\Documents\GitHub\VBS4Project\PythonPorjects\photomesh\OECPP.PMPreset"  # or "OECPP"
+ENFORCE_OBJ_ONLY = True  # keep OBJ-only + center/ellipsoid on
+
+PRESET_NAME_ONLY = stage_preset(PRESET_INPUT, enforce_obj_only=ENFORCE_OBJ_ONLY)
+
 
 def build_queue_payload(
     project_name: str,
     project_path: str,
     image_folders: Iterable[str],
     config,
-    preset_name: str | None = None,
 ) -> list[dict]:
     api = config.get("PhotoMeshAPI", {})
-    desired = (preset_name or api.get("preset") or "OECPP").strip()
-    enforce_obj_only = bool(api.get("enforce_obj_only", True))
-    preset_name_only = stage_preset(desired, enforce_obj_only=enforce_obj_only)
-
     working = api.get("working_fuser_unc", "")
     max_local = int(api.get("max_local_fusers", 4))
 
@@ -34,7 +36,7 @@ def build_queue_payload(
             "buildFrom": 1,
             "buildUntil": 6,
             "inheritBuild": "",
-            "preset": preset_name_only,
+            "preset": PRESET_NAME_ONLY,  # <- NAME ONLY, no extension
             "workingFolder": working,
             "MaxLocalFusers": max_local,
             "MaxAWSFusers": 0,


### PR DESCRIPTION
## Summary
- Hard-code the PhotoMesh preset and stage it via `stage_preset` so watcher queues send only the preset name
- Add helper functions to launch OBJ-only autostart builds and enforce wizard defaults
- Update STE Toolkit mesh creation to use the staged preset and new launch helpers

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b73073ae348322afcbd03fcae15c73

## Summary by Sourcery

Hard-code the PhotoMesh preset and centralize its staging to always queue only the preset name, while introducing helper functions for OBJ-only defaults and autostart builds and updating downstream code to use them

Enhancements:
- Hard-code the PhotoMesh preset path and stage it once at import to enforce sending only the preset name
- Add enforce_wizard_defaults_obj_only helper to configure OBJ-only build defaults
- Add launch_autostart_build helper to start the PhotoMesh Wizard with overrideSettings, autostart, and an optional preset
- Update STE Toolkit mesh creation to use the new defaults and autostart launch helpers with the staged preset
- Update REST API payload builder to use the hard-coded staged preset name and remove dynamic preset handling