### PR TITLE
Hard-code STEPRESET preset

### DIFF
--- a/PythonPorjects/STE_Toolkit.py
+++ b/PythonPorjects/STE_Toolkit.py
@@ -21,8 +21,10 @@ try:
     import psutil
 except Exception:  # pragma: no cover - psutil may not be installed
     psutil = None
+from photomesh_preset import stage_preset
 from photomesh_launcher import (
-    launch_wizard_with_preset,
+    enforce_wizard_defaults_obj_only,
+    launch_autostart_build,
     get_offline_cfg,
     ensure_offline_share_exists,
     can_access_unc,
@@ -3435,23 +3437,28 @@ class VBS4Panel(tk.Frame):
         self.log_message(f"Creating mesh for project: {project_name}")
 
         try:
-            host = config.get("Offline", "working_fuser_host", fallback="KIT1-1").strip()
+            host = config.get("Offline", "working_fuser_host", fallback="KIT1-1").strip() or "KIT1-1"
         except Exception:
             host = "KIT1-1"
         fuser_unc = rf"\\{host}\SharedMeshDrive\WorkingFuser"
-        desired = self.preset_entry.get().strip() or "OECPP"
+
+        # Hard-coded preset (same value used in watcher)
+        PRESET_INPUT = r"STEPRESET"  # or full path to .PMPreset
+        PRESET_NAME = stage_preset(PRESET_INPUT)
 
         try:
-            proc = launch_wizard_with_preset(
+            # Enforce Wizard JSON defaults: 3DModel ON, Ortho OFF, OBJ ON, 3DML OFF, pivot+ellipsoid ON
+            enforce_wizard_defaults_obj_only(fuser_unc=fuser_unc, log=self.log_message)
+
+            # Launch Wizard with --overrideSettings --autostart --preset <NAME ONLY>
+            proc = launch_autostart_build(
                 project_name,
                 project_path,
                 self.image_folder_paths,
-                preset=desired,
-                autostart=True,
-                fuser_unc=fuser_unc,
+                preset_name=PRESET_NAME,
                 log=self.log_message,
             )
-            self.log_message("PhotoMesh Wizard launched with --autostart.")
+            self.log_message(f"PhotoMesh Wizard launched with preset '{PRESET_NAME}' (autostart).")
             if hasattr(self, "detach_wizard_on_photomesh_start_by_pid"):
                 self.detach_wizard_on_photomesh_start_by_pid(proc.pid, project_path)
             self.start_progress_monitor(project_path)

--- a/PythonPorjects/photomesh_launcher.py
+++ b/PythonPorjects/photomesh_launcher.py
@@ -397,6 +397,49 @@ def enforce_photomesh_settings(preset: str = "", autostart: bool = True) -> None
     enforce_wizard_install_config(fuser_unc=fuser_unc)
     ensure_wizard_user_defaults(preset=preset, autostart=autostart)
 
+# -------------------- OBJ-only defaults + autostart launch --------------------
+def enforce_wizard_defaults_obj_only(
+    *, fuser_unc: Optional[str] = None, log=print
+) -> None:
+    """Enforce install config for OBJ-only build (Ortho OFF, OBJ ON)."""
+    enforce_wizard_install_config(
+        model3d=True,
+        obj=True,
+        d3dml=False,
+        ortho_ui=False,
+        center_pivot=True,
+        ellipsoid=True,
+        fuser_unc=fuser_unc,
+        log=log,
+    )
+
+
+def launch_autostart_build(
+    project_name: str,
+    project_path: str,
+    imagery_folders: Iterable[str],
+    *,
+    preset_name: str = "",
+    log=print,
+) -> subprocess.Popen:
+    """Launch PhotoMesh Wizard with --overrideSettings --autostart and optional --preset."""
+    args = [
+        WIZARD_EXE,
+        "--projectName",
+        project_name,
+        "--projectPath",
+        project_path,
+        "--overrideSettings",
+        "--autostart",
+    ]
+    if preset_name:
+        args += ["--preset", preset_name]
+    for folder in imagery_folders or []:
+        args += ["--folder", folder]
+
+    creationflags = getattr(subprocess, "CREATE_NO_WINDOW", 0)
+    return subprocess.Popen(args, cwd=WIZARD_DIR, creationflags=creationflags)
+
 # -------------------- Launch Wizard with preset --------------------
 def launch_wizard_with_preset(
     project_name: str,
@@ -427,7 +470,7 @@ def launch_wizard_with_preset(
         "--overrideSettings",
     ]
     if preset:
-        norm = stage_preset(preset, enforce_obj_only=False, log=log)
+        norm = stage_preset(preset)
         if norm:
             args += ["--preset", norm]
     if autostart:

--- a/PythonPorjects/photomesh_preset.py
+++ b/PythonPorjects/photomesh_preset.py
@@ -1,9 +1,4 @@
-import os
-import shutil
-import logging
-import xml.etree.ElementTree as ET
-
-LOG = logging.getLogger("pm_preset")
+import os, shutil, xml.etree.ElementTree as ET
 
 APPDATA_PRESETS = os.path.join(os.environ.get("APPDATA", ""), r"Skyline\PhotoMesh\Presets")
 INSTALL_PRESETS = r"C:\\Program Files\\Skyline\\PhotoMesh\\Presets"
@@ -17,68 +12,32 @@ def _ensure_dirs() -> None:
         pass
 
 
-def _normalize_to_name_only(preset: str) -> str:
-    """Return the bare preset name (no extension, no path)."""
+def _name_only(preset: str) -> str:
     v = (preset or "").strip().strip('"').strip("'")
     base = os.path.basename(v)
-    name, _ext = os.path.splitext(base)
-    return name if name else v
+    name, _ = os.path.splitext(base)
+    return name or v
 
 
-def _maybe_normalize_xml(preset_path: str, enforce_obj_only: bool, log=LOG.info) -> None:
-    if not enforce_obj_only:
-        return
-    try:
-        arr = "http://schemas.microsoft.com/2003/10/Serialization/Arrays"
-        ET.register_namespace("d3p1", arr)
-        tree = ET.parse(preset_path)
-        root = tree.getroot()
-        bp = root.find("./BuildParameters") or ET.SubElement(root, "BuildParameters")
-
-        ofs = bp.find("OutputFormats") or ET.SubElement(bp, "OutputFormats")
-        for c in list(ofs):
-            ofs.remove(c)
-        ET.SubElement(ofs, f"{{{arr}}}string").text = "OBJ"
-
-        (bp.find("CenterModelsToProject") or ET.SubElement(bp, "CenterModelsToProject")).text = "true"
-        (bp.find("CesiumReprojectZ") or ET.SubElement(bp, "CesiumReprojectZ")).text = "true"
-
-        for tag in ("IsDefault", "IsLastUsed"):
-            (root.find(tag) or ET.SubElement(root, tag)).text = "true"
-
-        tree.write(preset_path, encoding="utf-8", xml_declaration=True)
-        log(f"[preset] normalized to OBJ-only + center/ellipsoid: {preset_path}")
-    except Exception as e:  # pragma: no cover - best effort
-        log(f"⚠️ preset normalization skipped ({e})")
-
-
-def stage_preset(preset_input: str, enforce_obj_only: bool = False, log=LOG.info) -> str:
+def stage_preset(preset_input: str) -> str:
     """
-    Accepts either a preset NAME (e.g. 'OECPP') or a .PMPreset FILE path.
-    If a path is given, copies it into a Presets folder and returns the NAME-ONLY.
-    If a name is given, just returns the cleaned name (assumes it exists in a Presets folder).
+    Accept a NAME ('STEPRESET') or a .PMPreset path.
+    If path: copy to Program Files Presets (or AppData fallback).
+    Return the NAME-ONLY for API/Wizard calls.
+    (No normalization needed — your STEPRESET already enforces OBJ + center/ellipsoid.)
     """
     _ensure_dirs()
-    if not preset_input:
-        raise ValueError("preset_input is empty")
-
     if os.path.isfile(preset_input):
-        name = _normalize_to_name_only(preset_input)
-        dest_pf = os.path.join(INSTALL_PRESETS, f"{name}.PMPreset")
-        dest_ad = os.path.join(APPDATA_PRESETS, f"{name}.PMPreset")
+        name = _name_only(preset_input)
+        pf = os.path.join(INSTALL_PRESETS, f"{name}.PMPreset")
+        ad = os.path.join(APPDATA_PRESETS, f"{name}.PMPreset")
         try:
-            shutil.copy2(preset_input, dest_pf)
-            preset_path = dest_pf
-            log(f"[preset] staged to Program Files: {preset_path}")
+            shutil.copy2(preset_input, pf)
         except PermissionError:
-            shutil.copy2(preset_input, dest_ad)
-            preset_path = dest_ad
-            log(f"[preset] staged to AppData: {preset_path}")
-
-        _maybe_normalize_xml(preset_path, enforce_obj_only, log)
+            shutil.copy2(preset_input, ad)
         return name
+    return _name_only(preset_input)
 
-    name_only = _normalize_to_name_only(preset_input)
-    return name_only
 
 __all__ = ["stage_preset"]
+

--- a/PythonPorjects/photomesh_rest.py
+++ b/PythonPorjects/photomesh_rest.py
@@ -3,19 +3,19 @@ from typing import Iterable
 
 from photomesh_preset import stage_preset
 
+# === Preset (hard-coded) ===
+# Use either the NAME if it's already under a Presets folder, or the absolute file path:
+PRESET_INPUT = r"STEPRESET"  # or r"C:\\path\\to\\STEPRESET.PMPreset"
+PRESET_NAME_ONLY = stage_preset(PRESET_INPUT)
+
 
 def build_queue_payload(
     project_name: str,
     project_path: str,
     image_folders: Iterable[str],
     config,
-    preset_name: str | None = None,
 ) -> list[dict]:
     api = config.get("PhotoMeshAPI", {})
-    desired = (preset_name or api.get("preset") or "OECPP").strip()
-    enforce_obj_only = bool(api.get("enforce_obj_only", True))
-    preset_name_only = stage_preset(desired, enforce_obj_only=enforce_obj_only)
-
     working = api.get("working_fuser_unc", "")
     max_local = int(api.get("max_local_fusers", 4))
 
@@ -34,7 +34,7 @@ def build_queue_payload(
             "buildFrom": 1,
             "buildUntil": 6,
             "inheritBuild": "",
-            "preset": preset_name_only,
+            "preset": PRESET_NAME_ONLY,  # <- NAME ONLY, no extension
             "workingFolder": working,
             "MaxLocalFusers": max_local,
             "MaxAWSFusers": 0,

--- a/tests/test_launch_photomesh_wrapper.py
+++ b/tests/test_launch_photomesh_wrapper.py
@@ -36,7 +36,7 @@ def test_launch_wizard_with_preset(monkeypatch):
     )
     monkeypatch.setattr(
         "photomesh_launcher.stage_preset",
-        lambda preset, enforce_obj_only=False, log=None: preset,
+        lambda preset: preset,
     )
 
     launch_wizard_with_preset("proj", "path", ["a", "b"], preset="Preset")


### PR DESCRIPTION
## Summary
- Add `stage_preset` helper to copy a preset into PhotoMesh preset folders and return its name
- Hard-code `STEPRESET` and send the staged preset name to both REST queue payloads and the Wizard path
- Adjust wizard launcher to use staged preset names directly

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b73073ae348322afcbd03fcae15c73

## Summary by Sourcery

Enforce a single hard-coded STEPRESET for all PhotoMesh operations by centralizing preset staging, simplify preset handling logic, and add dedicated OBJ-only and autostart launch paths for the wizard.

New Features:
- Add stage_preset helper to copy or reference a .PMPreset and return its name-only identifier
- Hard-code STEPRESET as the preset for both REST API payloads and Wizard launches
- Introduce enforce_wizard_defaults_obj_only for OBJ-only wizard settings and launch_autostart_build to start PhotoMesh with overrideSettings and autostart

Enhancements:
- Simplify preset name extraction and remove XML normalization logic in photomesh_preset
- Streamline photomesh_launcher to use staged preset names directly and fallback host detection

Tests:
- Update test_launch_photomesh_wrapper to match the new stage_preset signature