### PR TITLE
Use STEPRESET preset and add watch-folder queue

### DIFF
--- a/PythonPorjects/STE_Toolkit.py
+++ b/PythonPorjects/STE_Toolkit.py
@@ -3433,12 +3433,23 @@ class VBS4Panel(tk.Frame):
         except Exception:
             host = "KIT1-1"
         fuser_unc = rf"\\{host}\SharedMeshDrive\WorkingFuser"
-        preset_name = "OECPP"
+        preset_name = "STEPRESET"
         repo_preset = os.path.join(
-            os.path.dirname(__file__), "photomesh", "OECPP.PMPreset"
+            os.path.dirname(__file__), "photomesh", f"{preset_name}.PMPreset"
         )
+        if not os.path.isfile(repo_preset):
+            candidates = [
+                os.path.join(os.environ.get("APPDATA", ""), "Skyline", "PhotoMesh", "Presets", f"{preset_name}.PMPreset"),
+                os.path.join(r"C:\\Program Files\\Skyline\\PhotoMesh\\Presets", f"{preset_name}.PMPreset"),
+            ]
+            repo_preset = next((p for p in candidates if p and os.path.isfile(p)), "")
 
-        stage_install_preset(repo_preset, preset_name)
+        if repo_preset:
+            stage_install_preset(repo_preset, preset_name, log=self.log_message)
+        else:
+            self.log_message(
+                f"⚠️ Preset '{preset_name}' not found; ensure it exists in a Presets folder."
+            )
         enforce_wizard_install_config(ortho_ui=True)
 
         try:

--- a/PythonPorjects/watch_folder_queue.py
+++ b/PythonPorjects/watch_folder_queue.py
@@ -1,0 +1,88 @@
+"""Simple watch-folder -> PhotoMesh Project Queue bridge.
+
+Monitors a directory for new sub-folders and submits them to the PhotoMesh
+REST Project Queue using a hard-coded preset. After submission the script
+starts the build and prints progress via SSE.
+
+This example avoids external dependencies by using polling for new folders
+and the ``requests`` package for HTTP calls.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+import requests
+from urllib.parse import quote
+
+
+PRESET_NAME = "STEPRESET"
+# Adjust these paths for your environment
+WATCH_FOLDER = r"C:\\Temp\\Watch"
+WORKING_FOLDER = r"C:\\Temp\\PhotoMeshWork"
+BASE_URL = "http://localhost:56790"
+
+
+class WatchFolderQueue:
+    """Poll a folder for new subdirectories and queue builds."""
+
+    def __init__(self, folder: str) -> None:
+        self.folder = folder
+        self.seen: set[str] = set()
+
+    def run(self) -> None:
+        os.makedirs(self.folder, exist_ok=True)
+        while True:
+            current = {e.path for e in os.scandir(self.folder) if e.is_dir()}
+            for path in sorted(current - self.seen):
+                self.seen.add(path)
+                try:
+                    self.process(path)
+                except Exception as exc:  # pragma: no cover - runtime feedback
+                    print(f"Error processing {path}: {exc}")
+            time.sleep(5)
+
+    # --- PhotoMesh REST helpers -------------------------------------------------
+    def process(self, folder_path: str) -> None:
+        folder_name = os.path.basename(folder_path)
+        project_path = os.path.join(WORKING_FOLDER, folder_name)
+        source_path = folder_path
+        data = [
+            {
+                "comment": f"Auto project: {folder_name}",
+                "action": 0,
+                "projectPath": project_path,
+                "buildFrom": 1,
+                "buildUntil": 6,
+                "inheritBuild": "",
+                "preset": PRESET_NAME,
+                "workingFolder": WORKING_FOLDER,
+                "MaxLocalFusers": 10,
+                "MaxAWSFusers": 0,
+                "AWSFuserStartupScript": "script",
+                "AWSBuildConfigurationName": "",
+                "AWSBuildConfigurationJsonPath": "",
+                "sourceType": 0,
+                "sourcePath": source_path,
+            }
+        ]
+
+        requests.post(f"{BASE_URL}/ProjectQueue/project/add", json=data)
+        requests.post(f"{BASE_URL}/Build/Start")
+        self.monitor_sse(WORKING_FOLDER)
+
+    def monitor_sse(self, working_folder: str) -> None:
+        """Connect to the SSE endpoint and print progress messages."""
+        url = f"{BASE_URL}/SSE?path={quote(working_folder)}"
+        try:
+            with requests.get(url, stream=True) as resp:
+                for line in resp.iter_lines():
+                    if line:
+                        print(line.decode("utf-8", "ignore"))
+        except Exception as exc:  # pragma: no cover - runtime feedback
+            print(f"SSE monitor error: {exc}")
+
+
+if __name__ == "__main__":  # pragma: no cover - manual invocation
+    WatchFolderQueue(WATCH_FOLDER).run()
+


### PR DESCRIPTION
## Summary
- Default to STEPRESET preset and copy from a fixed path
- Resolve preset sources flexibly and pass preset to Wizard CLI
- Add watch-folder script that queues and monitors PhotoMesh builds

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b7445c581c8322bb595c759398099e

## Summary by Sourcery

Use STEPRESET as the default PhotoMesh preset, enhance preset staging logic, update STE_Toolkit to adopt the new preset and warn when missing, and introduce a watch-folder queue script to automatically submit and monitor PhotoMesh builds via REST.

New Features:
- Add a watch-folder queue script that polls a directory and auto-submits PhotoMesh projects via REST API

Enhancements:
- Default to the STEPRESET preset and prefer copying from a fixed shipping path
- Implement flexible preset source resolution to locate .PMPreset files from various locations
- Always include the preset argument when launching the PhotoMesh Wizard
- Update STE_Toolkit to use STEPRESET and log a warning if the preset is not found