### PR TITLE
Handle locked preset copies with atomic replace and retries

### DIFF
--- a/tests/test_launch_photomesh_wrapper.py
+++ b/tests/test_launch_photomesh_wrapper.py
@@ -54,23 +54,24 @@ def test_launch_wizard_with_preset(monkeypatch):
         "b",
     ]
 def test_stage_install_preset(monkeypatch):
-    copies = []
+    calls = []
 
     monkeypatch.setattr(
         "photomesh_launcher.os.path.isfile", lambda p: True
     )
+
+    def fake_copy(src, dst, attempts=5, base_delay=0.3, log=print):
+        calls.append((src, dst))
+        return True
+
     monkeypatch.setattr(
-        "photomesh_launcher.os.makedirs", lambda p, exist_ok=True: None
-    )
-    monkeypatch.setattr(
-        "photomesh_launcher.shutil.copy2",
-        lambda src, dst: copies.append((src, dst)),
+        "photomesh_launcher._copy2_atomic_with_retries", fake_copy
     )
 
     stage_install_preset("repo.PMPreset", "Preset")
 
-    assert len(copies) == 3
-    assert all(src == "repo.PMPreset" for src, _ in copies)
+    assert len(calls) == 3
+    assert all(src == "repo.PMPreset" for src, _ in calls)
 
 
 def test_offline_cfg_resolution(monkeypatch):


### PR DESCRIPTION
## Summary
- Add `_files_equal` and `_copy2_atomic_with_retries` helpers for atomic `copy2` with backoff and skip-if-same logic
- Update `stage_install_preset` to use atomic replace with retries and graceful failure handling
- Adjust tests to cover new helper behavior

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b74757d698832292832bd084e98b20

## Summary by Sourcery

Introduce atomic preset copying with retries and integrate it into the preset staging workflow.

Enhancements:
- Add _files_equal helper to compare files by path, size, and content
- Implement _copy2_atomic_with_retries helper to perform atomic copy with exponential backoff, skip-if-same logic, and cleanup
- Refactor stage_install_preset to use atomic replace with retry logic, track successes, and gracefully handle locked targets

Tests:
- Update stage_install_preset tests to mock the atomic copy helper and assert expected call behavior