### PR TITLE
Keep 3DML outputs when Ortho disabled

### DIFF
--- a/PythonPorjects/STE_Toolkit.py
+++ b/PythonPorjects/STE_Toolkit.py
@@ -689,15 +689,17 @@ def enable_obj_in_photomesh_config():
                 cfg = json.load(f)
             ui = cfg.setdefault("DefaultPhotoMeshWizardUI", {})
             outs = ui.setdefault("OutputProducts", {})
+            # Keep base 3D model product ON; Ortho OFF by default in UI.
             outs["3DModel"] = True
-            outs["Ortho"] = False
+            outs["Ortho"]   = False
             m3d = ui.setdefault("Model3DFormats", {})
-            # turn all bools off then enable OBJ
+            # Ensure base 3D format (3DML) is ON and keep OBJ ON as an extra export.
+            # Optionally turn other formats off to avoid surprises.
             for k, v in list(m3d.items()):
-                if isinstance(v, bool):
+                if isinstance(v, bool) and k not in ("OBJ", "3DML"):
                     m3d[k] = False
-            m3d["OBJ"] = True
-            m3d["3DML"] = False
+            m3d["3DML"] = True   # CRITICAL: keep base 3D model enabled
+            m3d["OBJ"]  = True
             ui["CenterPivotToProject"] = True
             ui["CenterModelsToProject"] = True
             ui["ReprojectToEllipsoid"] = True
@@ -3447,6 +3449,7 @@ class VBS4Panel(tk.Frame):
                 self.image_folder_paths,
                 autostart=True,
                 fuser_unc=fuser_unc,
+                want_ortho=False,
                 log=self.log_message,
             )
             self.log_message("PhotoMesh Wizard launched with --autostart.")


### PR DESCRIPTION
## Summary
- Preserve 3DML as the base 3D output while adding OBJ export and disabling Ortho by default
- Add optional `want_ortho` flag to `launch_wizard_with_preset` and enforce 3DML/OBJ outputs
- Guard PhotoMesh Wizard configs to avoid a 'no outputs' deadlock

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b74e5bcc6483228002e54915a65585

## Summary by Sourcery

Protect against disabled outputs by disabling orthophoto by default, preserving the core 3DML format (with optional re-enabling via want_ortho), and adding an auto-fix routine to avoid invalid 'no outputs' states

New Features:
- Add want_ortho flag to launch_wizard_with_preset to control orthophoto output
- Introduce _ensure_valid_outputs function to auto-fix configurations when orthophoto is disabled

Bug Fixes:
- Prevent 'no outputs' deadlock by re-enabling 3DModel and 3DML when all outputs are off

Enhancements:
- Always preserve the base 3DML model and enable OBJ export by default when orthophoto is disabled
- Update STE_Toolkit enable_obj_in_photomesh_config to keep 3DML and OBJ enabled