### PR TITLE
Route PhotoMesh builds through Project Queue with OBJ-only preset

### DIFF
--- a/PythonPorjects/STE_Toolkit.py
+++ b/PythonPorjects/STE_Toolkit.py
@@ -22,9 +22,8 @@ try:
 except Exception:  # pragma: no cover - psutil may not be installed
     psutil = None
 from photomesh_launcher import (
-    install_embedded_preset,
     enforce_wizard_install_config,
-    launch_wizard_with_preset,
+    queue_build_with_preset,
     get_offline_cfg,
     ensure_offline_share_exists,
     can_access_unc,
@@ -34,7 +33,6 @@ from photomesh_launcher import (
     open_in_explorer,
     resolve_network_working_folder_from_cfg,
     enforce_photomesh_settings,
-    PRESET_NAME,
 )
 from collections import OrderedDict
 import time
@@ -3436,31 +3434,19 @@ class VBS4Panel(tk.Frame):
         except Exception:
             host = "KIT1-1"
         fuser_unc = rf"\\{host}\SharedMeshDrive\WorkingFuser"
-        try:
-            install_embedded_preset(log=self.log_message)
-        except Exception as e:
-            self.log_message(f"⚠️ Could not install embedded preset: {e}")
-        enforce_wizard_install_config(ortho_ui=False)
+        enforce_wizard_install_config(ortho_ui=False, fuser_unc=fuser_unc)
 
         try:
-            proc = launch_wizard_with_preset(
-                project_name,
-                project_path,
-                self.image_folder_paths,
-                preset=PRESET_NAME,
-                autostart=True,
-                fuser_unc=fuser_unc,
-                want_ortho=False,
+            queue_build_with_preset(
+                project_name=project_name,
+                project_dir=project_path,
+                imagery_folders=self.image_folder_paths,
                 log=self.log_message,
             )
-            self.log_message("PhotoMesh Wizard launched with --autostart.")
-            if hasattr(self, "detach_wizard_on_photomesh_start_by_pid"):
-                self.detach_wizard_on_photomesh_start_by_pid(proc.pid, project_path)
-            self.start_progress_monitor(project_path)
         except Exception as e:
-            error_message = f"Failed to start PhotoMesh Wizard.\nError: {str(e)}"
+            error_message = f"Failed to queue PhotoMesh build.\nError: {str(e)}"
             self.log_message(error_message)
-            messagebox.showerror("Launch Error", error_message, parent=self)
+            messagebox.showerror("Queue Error", error_message, parent=self)
 
             if messagebox.askyesno(
                 "Open Folder", "Would you like to open the project folder?", parent=self


### PR DESCRIPTION
## Summary
- keep 3DML enabled while seeding Wizard config so OBJ output remains valid
- add helpers to submit PhotoMesh projects to Project Queue and watch SSE status
- use the queue-based build flow in STE_Toolkit instead of launching the Wizard

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b75585226c83228ba05c4617c97ad4