### PR TITLE
Ensure PhotoMesh Wizard preset keeps 3DML/OBJ and disables Ortho

### DIFF
--- a/PythonPorjects/STE_Toolkit.py
+++ b/PythonPorjects/STE_Toolkit.py
@@ -3450,7 +3450,7 @@ class VBS4Panel(tk.Frame):
                 preset=PRESET_NAME,
                 autostart=True,
                 fuser_unc=fuser_unc,
-                want_ortho=False,
+                want_ortho=False,  # explicitly disable Ortho
                 log=self.log_message,
             )
             self.log_message("PhotoMesh Wizard launched with --autostart.")

--- a/tests/test_launch_photomesh_wrapper.py
+++ b/tests/test_launch_photomesh_wrapper.py
@@ -46,14 +46,14 @@ def test_launch_wizard_with_preset(monkeypatch):
         "proj",
         "--projectPath",
         "path",
-        "--overrideSettings",
-        "--preset",
-        PRESET_NAME,
-        "--autostart",
         "--folder",
         "a",
         "--folder",
         "b",
+        "--overrideSettings",
+        "--preset",
+        PRESET_NAME,
+        "--autostart",
     ]
 def test_install_embedded_preset(monkeypatch):
     calls = []


### PR DESCRIPTION
## Summary
- add `_ensure_valid_outputs` helper to repair configs missing 3DML when Ortho output is off
- launch PhotoMesh Wizard with folders before preset overrides, forcing `--overrideSettings` and preset
- explicitly disable Ortho when launching from STE Toolkit
- adjust test to match new CLI argument order

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b84b155c808322a8750b8828dfef68

## Summary by Sourcery

Repair legacy PhotoMesh configs to guarantee 3D model and 3DML outputs when orthophoto is disabled, enforce preset overrides and disable Ortho when launching the PhotoMesh Wizard, and adjust tests for the new CLI argument order.

Bug Fixes:
- Add helper to patch configs missing 3DML/OBJ outputs when Ortho is turned off.

Enhancements:
- Switch to direct JSON load/save in the output-validation helper.
- Reorder CLI arguments to always include --overrideSettings and --preset before imagery folders.
- Explicitly disable Ortho output when launching via the STE Toolkit.

Tests:
- Update launch wrapper test to match the new CLI argument ordering.