### PR TITLE
Use Wizard preset as default without overrides

### DIFF
--- a/tests/test_launch_photomesh_wrapper.py
+++ b/tests/test_launch_photomesh_wrapper.py
@@ -11,7 +11,6 @@ from photomesh_launcher import (
     launch_wizard_with_preset,
     get_offline_cfg,
     resolve_network_working_folder_from_cfg,
-    PRESET_NAME,
 )
 
 
@@ -37,9 +36,20 @@ def test_launch_wizard_with_preset(monkeypatch):
         lambda **kwargs: None,
     )
 
+    called["cleared"] = False
+
+    def fake_clear(log=print):
+        called["cleared"] = True
+
+    monkeypatch.setattr(
+        "photomesh_launcher.clear_wizard_preset_overrides",
+        fake_clear,
+    )
+
     launch_wizard_with_preset("proj", "path", ["a", "b"])
 
     assert called["cwd"] == "wizdir"
+    assert called["cleared"] is True
     assert called["args"] == [
         "wiz.exe",
         "--projectName",
@@ -50,9 +60,8 @@ def test_launch_wizard_with_preset(monkeypatch):
         "a",
         "--folder",
         "b",
-        "--overrideSettings",
         "--preset",
-        PRESET_NAME,
+        "PhotoMesh Default",
         "--autostart",
     ]
 def test_install_embedded_preset(monkeypatch):


### PR DESCRIPTION
## Summary
- remove `--overrideSettings` usage so the Wizard's preset runs as-is
- add helper to purge saved preset overrides from Wizard config
- launch the Wizard with an explicit preset and clear overrides first

## Testing
- `pytest tests/test_launch_photomesh_wrapper.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b85ba992088322bbd976c380ba5608

## Summary by Sourcery

Use the Wizard's default preset by removing the --overrideSettings flag, clear any stored overrides via a new helper, and update tests to confirm the new behavior.

New Features:
- Add helper clear_wizard_preset_overrides to purge saved Wizard preset overrides

Enhancements:
- Launch the Wizard with explicit preset without using overrideSettings and clear overrides first
- Update default preset to "PhotoMesh Default" in launch_wizard_with_preset

Tests:
- Add test to verify clear_wizard_preset_overrides is invoked and remove overrideSettings from launch tests