### PR TITLE
Remove override overrides and rely on preset for Wizard launch

### DIFF
--- a/tests/test_launch_photomesh_wrapper.py
+++ b/tests/test_launch_photomesh_wrapper.py
@@ -61,7 +61,7 @@ def test_launch_wizard_with_preset(monkeypatch):
         "--folder",
         "b",
         "--preset",
-        "PhotoMesh Default",
+        photomesh_launcher.PRESET_NAME,
         "--autostart",
     ]
 def test_install_embedded_preset(monkeypatch):


### PR DESCRIPTION
## Summary
- Launch PhotoMesh Wizard without `--overrideSettings`, passing only the chosen preset and logging the full CLI.
- Seed PhotoMesh Wizard config so 3D Model, 3DML and OBJ are enabled while Ortho remains off, with a guard to fix configs missing outputs.
- Update tests to expect the configured preset constant.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b864f8c33483228aa86aecd1758d89

## Summary by Sourcery

Remove custom override settings from PhotoMesh Wizard launch and rely solely on the provided preset; seed and repair the install config to enable 3D outputs and disable Ortho by default, and update tests to use the PRESET_NAME constant.

New Features:
- Invoke PhotoMesh Wizard using only the preset argument and clear any stored override stacks

Enhancements:
- Seed the Wizard install config to enable 3D Model, 3DML, OBJ and disable Ortho by default to prevent launch stalls
- Repair legacy install configs missing valid outputs before launch

Tests:
- Update tests to expect photomesh_launcher.PRESET_NAME instead of a hard-coded preset string