### PR TITLE
Ensure Wizard uses embedded STEP preset

### DIFF
--- a/tests/test_launch_photomesh_wrapper.py
+++ b/tests/test_launch_photomesh_wrapper.py
@@ -35,6 +35,10 @@ def test_launch_wizard_with_preset(monkeypatch):
         "photomesh_launcher.enforce_wizard_install_config",
         lambda **kwargs: None,
     )
+    monkeypatch.setattr(
+        "photomesh_launcher._resolve_preset_for_wizard",
+        lambda name: "wizdir/Presets/STEPRESET.PMPreset",
+    )
 
     called["cleared"] = False
 
@@ -56,13 +60,13 @@ def test_launch_wizard_with_preset(monkeypatch):
         "proj",
         "--projectPath",
         "path",
+        "--preset",
+        "wizdir/Presets/STEPRESET.PMPreset",
+        "--autostart",
         "--folder",
         "a",
         "--folder",
         "b",
-        "--preset",
-        photomesh_launcher.PRESET_NAME,
-        "--autostart",
     ]
 def test_install_embedded_preset(monkeypatch):
     calls = []


### PR DESCRIPTION
## Summary
- stage embedded preset into all Wizard preset folders
- resolve absolute preset path for Wizard and launch without overrides
- clear preset override stacks and improve logging

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b868b0ab908322a2470854308543e8

## Summary by Sourcery

Stage and locate embedded STEP presets in known Wizard directories and enforce their use when launching the PhotoMesh Wizard, while clearing override stacks and improving logging.

Enhancements:
- Define WIZARD_PRESET_DIRS and stage embedded PRESET_XML into all known Wizard preset folders.
- Introduce _resolve_preset_for_wizard to retrieve the absolute .PMPreset path from Wizard directories.
- Update launch_wizard_with_preset to clear previous override stacks, require an absolute preset path, build the CLI without override flags, and add detailed launch logging.

Tests:
- Adjust test_launch_photomesh_wrapper to mock preset resolution and verify the new preset argument ordering in the launch command.