### PR TITLE
build: purge preset logic; rely on install-level config.json

### DIFF
--- a/PythonPorjects/photomesh_launcher.py
+++ b/PythonPorjects/photomesh_launcher.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
-import os, sys, json, shutil, subprocess, tempfile, configparser, ctypes, time, uuid, errno
-import xml.etree.ElementTree as ET
+import os, sys, json, shutil, subprocess, tempfile, configparser, ctypes, time, uuid
 from typing import Iterable, Optional
 
 try:  # pragma: no cover - optional dependency
@@ -501,6 +500,36 @@ def enforce_photomesh_settings(autostart: bool = True) -> None:
     fuser_unc = resolve_network_working_folder_from_cfg(o)
     enforce_wizard_install_config(fuser_unc=fuser_unc)
     ensure_wizard_user_defaults(autostart=autostart)
+
+
+def clear_user_wizard_overrides() -> None:
+    """Remove user-level preset override stacks if present."""
+    import os
+    import json
+
+    p = os.path.join(
+        os.environ.get("LOCALAPPDATA", ""),
+        "Skyline",
+        "PhotoMesh",
+        "PhotomeshWizard",
+        "config.json",
+    )
+    if not os.path.isfile(p):
+        return
+    with open(p, "r", encoding="utf-8") as f:
+        cfg = json.load(f)
+    for k in (
+        "SelectedPresets",
+        "Selected Presets",
+        "PresetOverrides",
+        "LastPresetOverrides",
+        "PresetStack",
+        "SelectedPresetNames",
+    ):
+        if k in cfg:
+            cfg.pop(k, None)
+    with open(p, "w", encoding="utf-8") as f:
+        json.dump(cfg, f, indent=2)
 
 
 def _ensure_valid_outputs(config_path: str, log=print) -> None:


### PR DESCRIPTION
## Summary
- drop unused XML/preset imports
- add helper to clear user-level preset overrides

## Testing
- `python -m py_compile PythonPorjects/photomesh_launcher.py PythonPorjects/STE_Toolkit.py`


------
https://chatgpt.com/codex/tasks/task_e_68b894141fb48322b0f0d97f0fdc57e2

## Summary by Sourcery

Purge deprecated preset logic by removing unused XML imports, deprecating user-level override stacks in favor of install-level config, and introduce a helper to clear existing user preset overrides.

New Features:
- Add clear_user_wizard_overrides helper to purge user-level preset override stacks

Enhancements:
- Remove unused XML/preset imports
- Rely on install-level config.json instead of legacy user presets