### PR TITLE
Patch project preset before PhotoMesh build

### DIFF
--- a/PythonPorjects/STE_Toolkit.py
+++ b/PythonPorjects/STE_Toolkit.py
@@ -3360,7 +3360,7 @@ class VBS4Panel(tk.Frame):
             )
             if hasattr(self, "detach_wizard_on_photomesh_start_by_pid") and proc:
                 self.detach_wizard_on_photomesh_start_by_pid(proc.pid, project_path)
-            self.log_message("PhotoMesh Wizard launched with --overrideSettings (no preset).")
+            self.log_message("PhotoMesh Wizard project prepared and build started with patched preset.")
             self.start_progress_monitor(project_path)
         except Exception as e:
             error_message = f"Failed to start PhotoMesh Wizard.\nError: {str(e)}"

--- a/PythonPorjects/photomesh_launcher.py
+++ b/PythonPorjects/photomesh_launcher.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
-import os, sys, json, subprocess, tempfile, time
+import os, sys, json, subprocess, tempfile, time, glob
 import configparser, ctypes
 from typing import Iterable
+from xml.etree import ElementTree as ET
 
 try:  # pragma: no cover - optional dependency
     import requests  # type: ignore
@@ -17,6 +18,7 @@ except Exception:  # pragma: no cover - headless/test environments
 WIZARD_DIR         = r"C:\\Program Files\\Skyline\\PhotoMeshWizard"
 WIZARD_EXE         = rf"{WIZARD_DIR}\\PhotoMeshWizard.exe"
 WIZARD_INSTALL_CFG = rf"{WIZARD_DIR}\\config.json"
+TB_USER_SETTINGS   = os.path.join(os.environ.get("APPDATA", ""), "Skyline", "TerraBuilder", "UserSettingsPM.config")
 
 # Keys that would re-apply a preset/overrides (must be removed)
 _PRESET_KEYS = ("SelectedPreset","SelectedPresets","PresetStack","LastUsedPreset","PresetOverrides","Preset")
@@ -75,26 +77,134 @@ def set_wizard_defaults_exact(log=print) -> None:
         f"CenterModelsToProject={ui.get('CenterModelsToProject')}, "
         f"ReprojectToEllipsoid={ui.get('ReprojectToEllipsoid')}")
 
+
+def _find_project_preset(project_name: str, project_path: str, since_ts: float) -> str:
+    """Return path to the newest .PMPreset created since *since_ts*.
+
+    Searches both the user's AppData presets directory and the project
+    folder itself.  Prefers files whose name contains *project_name*.
+    """
+    candidates: list[str] = []
+    appdata = os.environ.get("APPDATA")
+    if appdata:
+        preset_dir = os.path.join(appdata, "Skyline", "PhotoMesh", "Presets")
+        candidates.extend(glob.glob(os.path.join(preset_dir, "*.PMPreset")))
+    candidates.extend(glob.glob(os.path.join(project_path, "*.PMPreset")))
+    candidates = [p for p in candidates if os.path.getmtime(p) >= since_ts]
+    if not candidates:
+        return ""
+    named = [p for p in candidates if project_name.lower() in os.path.basename(p).lower()]
+    if named:
+        return max(named, key=os.path.getmtime)
+    return max(candidates, key=os.path.getmtime)
+
+
+def _ensure_xml_path(root: ET.Element, path: str) -> ET.Element:
+    """Ensure *path* exists under *root* and return the final element."""
+    cur = root
+    for part in path.split("/"):
+        nxt = cur.find(part)
+        if nxt is None:
+            nxt = ET.SubElement(cur, part)
+        cur = nxt
+    return cur
+
+
+def _patch_pmpreset_xml(path: str, log=print) -> None:
+    """Set required build flags to ``true`` in the project preset."""
+    try:
+        tree = ET.parse(path)
+        root = tree.getroot()
+    except Exception as e:  # pragma: no cover - parsing errors rare
+        log(f"[Preset] Failed to parse {path}: {e}")
+        return
+
+    flags = [
+        "BuildParameters/OutputProducts/Model3D",
+        "BuildParameters/Model3DFormats/OBJ",
+        "BuildParameters/Model3DFormats/3DML",
+        "BuildParameters/CenterPivotToProject",
+        "BuildParameters/CenterModelsToProject",
+        "BuildParameters/ReprojectToEllipsoid",
+    ]
+    for xpath in flags:
+        elem = _ensure_xml_path(root, xpath)
+        elem.text = "true"
+
+    tree.write(path, encoding="utf-8")
+    log(f"[Preset] Patched {path}")
+
+
+def _wait_for_user_settings_unlock(path: str = TB_USER_SETTINGS, retries: int = 5, delay: float = 1.0, log=print) -> None:
+    """Wait for TerraBuilder's UserSettingsPM.config to be free for access."""
+    if not path:
+        return
+    for i in range(retries):
+        try:
+            with open(path, "a+"):
+                return
+        except OSError:
+            log(f"[Wizard] UserSettingsPM.config locked; retry {i + 1}/{retries}")
+            time.sleep(delay)
+    log("[Wizard] Proceeding despite locked UserSettingsPM.config")
+
 def launch_wizard_new_project(project_name: str, project_path: str, folders, log=print) -> subprocess.Popen:
     """
-    Write install defaults, then launch Wizard for a NEW project.
-    - No presets passed.
-    - Use --overrideSettings so Build Settings honor our defaults.
-    - folders: iterable of image folder paths.
+    Write install defaults, launch Wizard to create the project (no autostart),
+    patch the emitted project preset, then relaunch with ``--autostart``.
+    Only documented CLI flags are used when invoking the Wizard.
+
+    Returns the ``Popen`` handle of the autostarted Wizard process.
     """
-    set_wizard_defaults_exact(log=log)   # write FIRST
-    time.sleep(0.2)                      # small settle to avoid AV/IO races
-    args = [
+    set_wizard_defaults_exact(log=log)
+    time.sleep(0.2)
+
+    # Initial launch without autostart so the project preset is generated
+    prep_args = [
         WIZARD_EXE,
-        "--projectName", project_name,
-        "--projectPath", project_path,
-        "--autostart",
-        "--overrideSettings",
+        "--projectName",
+        project_name,
+        "--projectPath",
+        project_path,
     ]
     for f in folders or []:
-        args += ["--folder", f]
-    log(f"[Wizard] {' '.join(args)}")
-    return subprocess.Popen(args, close_fds=False)
+        prep_args += ["--folder", f]
+    log(f"[Wizard-prepare] {' '.join(prep_args)}")
+    t0 = time.time()
+    _wait_for_user_settings_unlock(log=log)
+    proc = subprocess.Popen(prep_args, close_fds=False)
+
+    # Wait for the project preset to appear
+    preset_path = ""
+    deadline = time.time() + 60
+    while time.time() < deadline:
+        preset_path = _find_project_preset(project_name, project_path, t0)
+        if preset_path:
+            break
+        time.sleep(0.5)
+    if preset_path:
+        _patch_pmpreset_xml(preset_path, log=log)
+    else:
+        log("[Wizard] No project preset found; build may use defaults.")
+
+    # Close the preparation instance
+    try:
+        proc.terminate()
+    except Exception:
+        pass
+
+    # Relaunch with autostart to begin build
+    start_args = [
+        WIZARD_EXE,
+        "--projectName",
+        project_name,
+        "--projectPath",
+        project_path,
+        "--autostart",
+    ]
+    log(f"[Wizard-start] {' '.join(start_args)}")
+    _wait_for_user_settings_unlock(log=log)
+    return subprocess.Popen(start_args, close_fds=False)
 
 # Load shared configuration for network fuser settings
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))


### PR DESCRIPTION
## Summary
- Ensure the Wizard runs only with documented flags and no override preset arguments
- Retry Wizard startup until TerraBuilder's UserSettingsPM.config is unlocked

## Testing
- `python -m py_compile PythonPorjects/photomesh_launcher.py PythonPorjects/STE_Toolkit.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b8e3fb0b6c83229ee7d37ad2c2f9b9