### PR TITLE
Ensure PhotoMesh Wizard defaults enable OBJ

### DIFF
--- a/PythonPorjects/STE_Toolkit.py
+++ b/PythonPorjects/STE_Toolkit.py
@@ -34,6 +34,8 @@ from photomesh_launcher import (
     working_share_root,
     working_fuser_unc,
     _read_photomesh_host,
+    apply_minimal_wizard_defaults,
+    launch_wizard_new_project,
 )
 from collections import OrderedDict
 import time
@@ -3351,7 +3353,8 @@ class VBS4Panel(tk.Frame):
         self.log_message(f"Creating mesh for project: {project_name}")
 
         try:
-            from photomesh_launcher import launch_wizard_new_project
+            apply_minimal_wizard_defaults()
+            enforce_photomesh_settings()
             proc = launch_wizard_new_project(
                 project_name=project_name,
                 project_path=project_path,

--- a/PythonPorjects/update_photomesh_config.py
+++ b/PythonPorjects/update_photomesh_config.py
@@ -1,27 +1,7 @@
 import json
-import sys
-import ctypes
 import os
 
 CONFIG_PATH = r"C:\Program Files\Skyline\PhotoMeshWizard\config.json"
-
-
-def is_admin() -> bool:
-    """Check for administrative privileges on Windows."""
-    try:
-        return ctypes.windll.shell32.IsUserAnAdmin()
-    except Exception:
-        return False
-
-
-def elevate() -> bool:
-    """Attempt to relaunch the script with admin rights."""
-    params = " ".join(f'"{arg}"' for arg in sys.argv)
-    try:
-        ret = ctypes.windll.shell32.ShellExecuteW(None, "runas", sys.executable, params, None, 1)
-        return int(ret) > 32
-    except Exception:
-        return False
 
 
 def update_config(path: str) -> None:
@@ -38,8 +18,13 @@ def update_config(path: str) -> None:
         print(f"❌ Failed to parse JSON: {exc}")
         return
 
-    # Update the desired field
-    config.setdefault("DefaultPhotoMeshWizardUI", {}).setdefault("Model3DFormats", {})["OBJ"] = True
+    ui = config.setdefault("DefaultPhotoMeshWizardUI", {})
+    ui.setdefault("OutputProducts", {}).update({"Model3D": True})
+    fmts = ui.setdefault("Model3DFormats", {})
+    fmts["3DML"] = True
+    fmts["OBJ"] = True
+    # Optional:
+    # fmts["LAS"] = True
 
     try:
         with open(path, "w", encoding="utf-8") as f:
@@ -53,12 +38,4 @@ def update_config(path: str) -> None:
 
 
 if __name__ == "__main__":
-    if not is_admin():
-        print("⚠️  This script needs to run with Administrator privileges.")
-        if elevate():
-            sys.exit(0)
-        else:
-            print("❌ Could not obtain elevated privileges. Please rerun this script as Administrator.")
-            sys.exit(1)
     update_config(CONFIG_PATH)
-    input("Press Enter to exit...")


### PR DESCRIPTION
## Summary
- ensure installer-level PhotoMesh Wizard config enables Model3D with OBJ and 3DML
- call minimal config enforcement before launching PhotoMesh Wizard
- simplify standalone config updater to set Model3D/OBJ/3DML without elevation

## Testing
- `python -m py_compile PythonPorjects/photomesh_launcher.py PythonPorjects/STE_Toolkit.py PythonPorjects/update_photomesh_config.py`

------
https://chatgpt.com/codex/tasks/task_e_68b8ed53c83c8322afd3866a86b1f375