### PR TITLE
chore: suppress imagery selection toast

### DIFF
--- a/PythonPorjects/STE_Toolkit.py
+++ b/PythonPorjects/STE_Toolkit.py
@@ -74,6 +74,9 @@ logging.basicConfig(
     format='%(asctime)s - %(levelname)s - %(message)s'
 )
 
+# --- UI toasts ---
+SHOW_SELECTION_TOAST = False
+
 
 _lock_file = None
 #------------SINGLETON DEF------------------------------------------------------
@@ -3137,11 +3140,18 @@ class VBS4Panel(tk.Frame):
             norm_folders = [clean_path(f) for f in folders]
             self.image_folder_paths = norm_folders
             self.image_folder_path = ";".join(norm_folders)
-            messagebox.showinfo(
-                "Imagery Selected",
-                "Selected imagery folders:\n" + "\n".join(norm_folders),
-                parent=folder_window,
-            )
+            if SHOW_SELECTION_TOAST:
+                messagebox.showinfo(
+                    "Imagery Selected",
+                    f"Selected imagery folders:\n{', '.join(self.image_folder_paths)}",
+                    parent=folder_window,
+                )
+            else:
+                # keep a breadcrumb in the log; NO modal dialog
+                if hasattr(self, "log_message"):
+                    self.log_message(
+                        f"Imagery selected: {', '.join(self.image_folder_paths)}"
+                    )
             self.log_message("Selected imagery folders:")
             for folder in norm_folders:
                 self.log_message(f" - {folder}")


### PR DESCRIPTION
## Summary
- add optional UI toast toggle for imagery selection
- log imagery selections instead of popup dialog by default

## Testing
- `python -m py_compile PythonPorjects/STE_Toolkit.py`


------
https://chatgpt.com/codex/tasks/task_e_68b8f13f0b948322bb6b23c1976cad1c

## Summary by Sourcery

Introduce a toggle to suppress the imagery selection popup and record selections in the log by default.

New Features:
- Add SHOW_SELECTION_TOAST flag to enable or disable imagery selection toast notifications.

Enhancements:
- Default to logging imagery selections instead of showing a modal dialog.