### PR TITLE
feat: add sticky projects root

### DIFF
--- a/PythonPorjects/config.ini
+++ b/PythonPorjects/config.ini
@@ -37,3 +37,6 @@ working_fuser_subdir = WorkingFuser
 use_ip_unc = False
 working_fuser_host = KIT1-1
 
+
+[Paths]
+projects_root =

--- a/PythonPorjects/photomesh_launcher.py
+++ b/PythonPorjects/photomesh_launcher.py
@@ -82,6 +82,26 @@ CONFIG_PATH = os.path.join(BASE_DIR, "config.ini")
 config = configparser.ConfigParser()
 config.read(CONFIG_PATH)
 
+
+def _save_config():
+    with open(CONFIG_PATH, "w", encoding="utf-8") as f:
+        config.write(f)
+
+
+def get_projects_root() -> str:
+    try:
+        root = config.get("Paths", "projects_root", fallback="").strip()
+        return root
+    except Exception:
+        return ""
+
+
+def set_projects_root(path: str) -> None:
+    if not config.has_section("Paths"):
+        config.add_section("Paths")
+    config.set("Paths", "projects_root", path)
+    _save_config()
+
 # ---------- Host / UNC helpers (read from GUI Settings) ----------
 def _read_photomesh_host() -> str:
     """


### PR DESCRIPTION
## Summary
- add config helpers for persistent Projects root
- automatically use saved Projects root when creating meshes
- expose a Settings button to change the Projects root

## Testing
- `python -m py_compile PythonPorjects/STE_Toolkit.py PythonPorjects/photomesh_launcher.py`


------
https://chatgpt.com/codex/tasks/task_e_68b8f3b0254c832295336f82791a797c