### PR TITLE
Integrate PhotoMesh Project Queue into one-click workflow

### DIFF
--- a/PythonPorjects/STE_Toolkit.py
+++ b/PythonPorjects/STE_Toolkit.py
@@ -68,8 +68,8 @@ from photomesh_launcher import (
     working_share_root,
     working_fuser_unc,
     _read_photomesh_host,
-    apply_minimal_wizard_defaults,
-    launch_wizard_new_project,
+    queue_build_from_gui_selection,
+    ensure_photomesh_queue_running,
 )
 from collections import OrderedDict
 import time
@@ -3446,6 +3446,19 @@ class VBS4Panel(tk.Frame):
                 self.log_message(f"Failed to start {name}: {e}")
 
     def create_mesh(self):
+        try:
+            launch_photomesh_main()
+        except FileNotFoundError as e:
+            messagebox.showerror("PhotoMesh", str(e), parent=self)
+            return
+        if not wait_for_queue_ready():
+            messagebox.showerror(
+                "PhotoMesh",
+                "Project Queue API not available on localhost:8087",
+                parent=self,
+            )
+            return
+
         if not hasattr(self, 'image_folder_paths') or not self.image_folder_paths:
             self.select_imagery()
             if not hasattr(self, 'image_folder_paths') or not self.image_folder_paths:
@@ -3473,11 +3486,12 @@ class VBS4Panel(tk.Frame):
                 parent=self,
             )
             if not project_path:
-                messagebox.showwarning("Missing Folder", "Project output folder is required.", parent=self)
-                return
-            set_projects_root(project_path)
-            if hasattr(self, "log_message"):
-                self.log_message(f"Saved Projects root: {project_path}")
+                first_img = self.image_folder_paths[0]
+                project_path = os.path.dirname(first_img)
+            else:
+                set_projects_root(project_path)
+                if hasattr(self, "log_message"):
+                    self.log_message(f"Saved Projects root: {project_path}")
 
         project_path = os.path.normpath(project_path)
         project_dir = clean_path(os.path.join(project_path, project_name))
@@ -3485,27 +3499,33 @@ class VBS4Panel(tk.Frame):
 
         self.log_message(f"Creating mesh for project: {project_name}")
 
+        image_folders = self.image_folder_paths
+
         try:
-            apply_minimal_wizard_defaults()
-            enforce_photomesh_settings()
-            proc = launch_wizard_new_project(
+            working_unc = config.get("Paths", "NetworkWorkingFolder", fallback="").strip()
+            if not working_unc:
+                working_unc = config.get("Offline", "network_working_folder", fallback="").strip()
+        except Exception:
+            working_unc = ""
+
+        preset_src = None  # optional preset path or None
+
+        try:
+            self.log_message("Starting PhotoMesh so queue is available…")
+            ensure_photomesh_queue_running(log=self.log_message, wait_seconds=90)
+            self.log_message("Submitting project to PhotoMesh queue…")
+            queue_build_from_gui_selection(
                 project_name=project_name,
-                project_path=project_dir,
-                folders=self.image_folder_paths,
-                log=self.log_message,
+                project_dir=project_dir,
+                image_folders=image_folders,
+                working_folder=working_unc,
+                preset_src=preset_src,
+                log=self.log_message if hasattr(self, "log_message") else print,
             )
-            if hasattr(self, "detach_wizard_on_photomesh_start_by_pid") and proc:
-                self.detach_wizard_on_photomesh_start_by_pid(proc.pid, project_dir)
-            self.log_message("PhotoMesh Wizard launched with --overrideSettings (no preset).")
-            self.start_progress_monitor(project_dir)
+            self.log_message(f"Queued project '{project_name}' and started build.")
         except Exception as e:
-            error_message = f"Failed to start PhotoMesh Wizard.\nError: {str(e)}"
-            self.log_message(error_message)
-            messagebox.showerror("Launch Error", error_message, parent=self)
-            if messagebox.askyesno(
-                "Open Folder", "Would you like to open the project folder?", parent=self
-            ):
-                open_in_explorer(project_dir)
+            self.log_message(f"Queue error: {e}")
+            messagebox.showerror("PhotoMesh Queue Error", str(e), parent=self)
 
     def view_mesh(self):
         terra_explorer_path = r"C:\Program Files\Skyline\TerraExplorer Pro\TerraExplorer.exe"

--- a/PythonPorjects/photomesh_launcher.py
+++ b/PythonPorjects/photomesh_launcher.py
@@ -25,15 +25,21 @@ import configparser
 import ctypes
 import json
 import os
+import socket
 import subprocess
 import sys
 import time
-from typing import Iterable
+from typing import Iterable, List
 
 try:  # pragma: no cover - optional dependency
     import requests  # type: ignore
 except Exception:  # pragma: no cover - requests may be absent in minimal environments
     requests = None  # type: ignore
+
+try:  # pragma: no cover - psutil may not be installed
+    import psutil  # type: ignore
+except Exception:  # pragma: no cover
+    psutil = None  # type: ignore
 
 try:  # pragma: no cover - tkinter may not be available
     from tkinter import messagebox
@@ -58,7 +64,12 @@ CONFIG_PATH = os.path.join(BASE_DIR, "config.ini")
 # Queue endpoints and working directory used by the PhotoMesh engine
 QUEUE_API_URL = "http://127.0.0.1:8087/ProjectQueue/"
 QUEUE_SSE_URL = "http://127.0.0.1:8087/ProjectQueue/events"
+QUEUE_HOST = "127.0.0.1"
+QUEUE_PORT = 8087
 WORKING_FOLDER = r"C:\\WorkingFolder"
+
+PHOTOMESH_EXE = r"C:\\Program Files\\Skyline\\PhotoMesh\\PhotoMesh.exe"
+QUEUE_READY_TIMEOUT_SEC = 90
 
 # Off-line connection hint shown when UNC paths fail
 OFFLINE_ACCESS_HINT = (
@@ -541,6 +552,221 @@ def poll_queue_until_done(
             pass
         time.sleep(poll_every)
     log("[Queue] Monitor window expired.")
+
+# =============================================================================
+# PhotoMesh Project Queue integration (no Wizard)
+# =============================================================================
+
+
+def _is_listening(host: str, port: int, timeout_sec: float = 0.5) -> bool:
+    """Return True if *host:port* accepts a TCP connection."""
+    try:
+        with socket.create_connection((host, port), timeout=timeout_sec):
+            return True
+    except OSError:
+        return False
+
+
+def _is_photomesh_running() -> bool:
+    """Check whether PhotoMesh.exe is already running."""
+    try:
+        if psutil:
+            for p in psutil.process_iter(["name", "exe"]):
+                nm = (p.info.get("name") or "").lower()
+                if nm == "photomesh.exe":
+                    return True
+    except Exception:
+        pass
+    try:
+        out = subprocess.check_output(["tasklist"], text=True, stderr=subprocess.DEVNULL)
+        return "PhotoMesh.exe" in out
+    except Exception:
+        return False
+
+
+def launch_photomesh_main() -> subprocess.Popen | None:
+    """Start PhotoMesh.exe if it isn't already running."""
+    if _is_photomesh_running():
+        return None
+    if not os.path.isfile(PHOTOMESH_EXE):
+        raise FileNotFoundError(f"PhotoMesh.exe not found at {PHOTOMESH_EXE}")
+    return subprocess.Popen([PHOTOMESH_EXE], cwd=os.path.dirname(PHOTOMESH_EXE))
+
+
+def wait_for_queue_ready(max_wait_sec: int = QUEUE_READY_TIMEOUT_SEC) -> bool:
+    """Wait until the Project Queue TCP port is listening."""
+    start = time.time()
+    while time.time() - start < max_wait_sec:
+        if _is_listening(QUEUE_HOST, QUEUE_PORT):
+            return True
+        time.sleep(1.0)
+    return False
+
+
+def ensure_dir(path: str) -> None:
+    os.makedirs(path, exist_ok=True)
+
+
+def wait_for_dir(path: str, timeout: int = 60, poll: float = 0.5) -> None:
+    """Wait up to *timeout* seconds for *path* to exist; create if missing."""
+    end = time.time() + timeout
+    while time.time() < end:
+        if os.path.isdir(path):
+            return
+        time.sleep(poll)
+    os.makedirs(path, exist_ok=True)
+
+
+def make_source_path_from_folders(folders: List[str]) -> List[dict]:
+    """
+    Build the 'sourcePath' list for /project/add from the already-selected image folders.
+    If subfolders contain JPG/JPEG, treat each subfolder as a collection; else use folder.
+    """
+    out: List[dict] = []
+    for folder in folders or []:
+        if not os.path.isdir(folder):
+            continue
+        subdirs = [d for d in os.listdir(folder) if os.path.isdir(os.path.join(folder, d))]
+        collections = []
+        if subdirs:
+            for s in subdirs:
+                p = os.path.join(folder, s)
+                try:
+                    has_jpg = any(fn.lower().endswith((".jpg", ".jpeg")) for fn in os.listdir(p))
+                except Exception:
+                    has_jpg = False
+                if has_jpg:
+                    collections.append({"name": s, "path": p, "properties": ""})
+        if not collections:
+            collections = [{"name": "RGB", "path": folder, "properties": ""}]
+        out.extend(collections)
+    return out
+
+
+def build_queue_payload(
+    project_name: str,
+    project_dir: str,
+    source_path: List[dict],
+    working_folder: str,
+    preset_name: str | None = None,
+) -> list[dict]:
+    """
+    Create /project/add payload. If preset_name is None/empty, engine defaults apply.
+    """
+    ensure_dir(project_dir)
+    ensure_dir(working_folder)
+    project_xml = os.path.join(project_dir, f"{project_name}.PhotoMeshXML")
+    return [{
+        "comment": f"Auto project: {project_name}",
+        "action": 0,
+        "projectPath": project_xml,
+        "buildFrom": 1,
+        "buildUntil": 6,
+        "inheritBuild": "",
+        "preset": preset_name or "",
+        "workingFolder": working_folder,
+        "MaxLocalFusers": 10,
+        "MaxAWSFusers": 0,
+        "AWSFuserStartupScript": "",
+        "AWSBuildConfigurationName": "",
+        "AWSBuildConfigurationJsonPath": "",
+        "sourceType": 0,
+        "sourcePath": source_path
+    }]
+
+
+def submit_project_to_queue(payload: list[dict], log=print) -> None:
+    """POST /project/add and raise on failure."""
+    if not requests:
+        raise RuntimeError("requests library is required for queue submission")
+    r = requests.post(QUEUE_API_URL + "project/add", json=payload, timeout=30)
+    if r.status_code != 200:
+        raise RuntimeError(f"/project/add failed [{r.status_code}]: {r.text}")
+    log("Submitted project to Project Queue.")
+
+
+def start_build(log=print) -> None:
+    """GET /Build/Start and raise on failure."""
+    if not requests:
+        raise RuntimeError("requests library is required for queue submission")
+    r = requests.get(QUEUE_API_URL + "Build/Start", timeout=30)
+    if r.status_code != 200:
+        raise RuntimeError(f"/Build/Start failed [{r.status_code}]: {r.text}")
+    log("Build started.")
+
+
+# =============================================================================
+# Optional: engine preset staging (only if you WANT to use a preset by name)
+# =============================================================================
+import shutil
+import xml.etree.ElementTree as ET
+
+ENGINE_PRESET_DIR = r"C:\\Program Files\\Skyline\\PhotoMesh\\Presets"
+
+
+def _read_preset_name(pmpreset_path: str) -> str:
+    try:
+        root = ET.parse(pmpreset_path).getroot()
+        n = root.find(".//PresetName")
+        if n is not None and (n.text or "").strip():
+            return n.text.strip()
+    except Exception:
+        pass
+    return os.path.splitext(os.path.basename(pmpreset_path))[0]
+
+
+def install_engine_preset(pmpreset_path: str, log=print) -> str:
+    """Copy .PMPreset into engine Presets so 'preset' resolves by name in /project/add."""
+    if not os.path.isfile(pmpreset_path):
+        raise FileNotFoundError(pmpreset_path)
+    if not pmpreset_path.lower().endswith(".pmpreset"):
+        raise ValueError("Expected a .PMPreset file")
+
+    name = _read_preset_name(pmpreset_path)
+    dst = os.path.join(ENGINE_PRESET_DIR, f"{name}.PMPreset")
+
+    try:
+        os.makedirs(ENGINE_PRESET_DIR, exist_ok=True)
+        if not os.path.isfile(dst) or os.path.getmtime(pmpreset_path) > os.path.getmtime(dst):
+            shutil.copy2(pmpreset_path, dst)
+            log(f"Installed engine preset → {dst}")
+        else:
+            log(f"Engine preset already up to date → {dst}")
+    except PermissionError as e:
+        raise PermissionError(
+            f"Cannot copy preset to '{ENGINE_PRESET_DIR}'. "
+            f"Run once as Administrator or copy manually."
+        ) from e
+    return name
+
+
+def queue_build_from_gui_selection(
+    project_name: str,
+    project_dir: str,
+    image_folders: List[str],
+    working_folder: str,
+    preset_src: str | None = None,
+    log=print,
+) -> None:
+    """
+    Do not change GUI. Ensure PhotoMesh is running, guarantee directories exist,
+    build payload from current selection, submit, and start build.
+    """
+    ensure_photomesh_queue_running(log=log, wait_seconds=QUEUE_READY_TIMEOUT_SEC)
+    wait_for_dir(project_dir, timeout=30)
+    ensure_dir(working_folder)
+
+    src = make_source_path_from_folders(image_folders)
+    if not src:
+        raise ValueError("No valid imagery found for sourcePath.")
+
+    preset_name = None
+    if preset_src:
+        preset_name = install_engine_preset(preset_src, log=log)
+
+    payload = build_queue_payload(project_name, project_dir, src, working_folder, preset_name)
+    submit_project_to_queue(payload, log=log)
+    start_build(log=log)
 # endregion
 
 # region GUI / Tkinter handlers
@@ -578,6 +804,14 @@ __all__ = [
     "find_wizard_exe",
     "submit_queue_build",
     "poll_queue_until_done",
+    "queue_build_from_gui_selection",
+    "launch_photomesh_main",
+    "wait_for_queue_ready",
+    "make_source_path_from_folders",
+    "build_queue_payload",
+    "submit_project_to_queue",
+    "start_build",
+    "install_engine_preset",
 ]
 
 # =============================================================================


### PR DESCRIPTION
## Summary
- launch PhotoMesh main app and wait for queue availability before imagery selection
- provide socket-based helpers to check queue port and process state
- queue builds via existing selection assuming engine is already up
- ensure project output and working directories exist before submitting to queue

## Testing
- `python -m py_compile PythonPorjects/photomesh_launcher.py`
- `python -m py_compile PythonPorjects/STE_Toolkit.py`


------
https://chatgpt.com/codex/tasks/task_e_68b98f304c108322bb6b335f6707140f

## Summary by Sourcery

Integrate PhotoMesh Project Queue into a one-click workflow by adding engine launch and readiness checks, directory management, queue API integration, and updating the STE_Toolkit GUI to submit and start builds via the queue.

New Features:
- Add helpers to launch and detect the PhotoMesh engine (_is_photomesh_running, launch_photomesh_main, _is_listening, wait_for_queue_ready).
- Provide directory management functions (ensure_dir, wait_for_dir) and a builder for queue payloads (build_queue_payload).
- Implement API integration functions (submit_project_to_queue, start_build) and a unified queue build entry point (queue_build_from_gui_selection).
- Add install_engine_preset for optional staging of engine presets into the PhotoMesh Presets directory.
- Update STE_Toolkit.create_mesh to launch PhotoMesh, wait for the queue, and queue projects directly from the GUI selection.

Enhancements:
- Consolidate legacy wizard-based build logic into a streamlined queue-driven workflow.
- Enhance PhotoMesh.exe process detection with a psutil-based check and a tasklist fallback.