### PR TITLE
Pre-launch PhotoMesh queue before One-Click selection

### DIFF
--- a/PythonPorjects/STE_Toolkit.py
+++ b/PythonPorjects/STE_Toolkit.py
@@ -68,6 +68,7 @@ from photomesh_launcher import (
     working_share_root,
     working_fuser_unc,
     _read_photomesh_host,
+    prelaunch_photomesh_queue,
     queue_build_from_gui_selection,
 )
 from collections import OrderedDict
@@ -3083,8 +3084,55 @@ class VBS4Panel(tk.Frame):
         if hasattr(self.controller, "update_navigation"):
             self.controller.update_navigation()
 
-    def on_oneclick_convert(self):
-        self.one_click_conversion()
+    def get_projects_root_default(self) -> str:
+        """Thin wrapper around saved Projects root configuration."""
+        return get_projects_root()
+
+    def set_projects_root_default(self, path: str) -> None:
+        """Persist Projects root selection for next time."""
+        set_projects_root(path)
+
+    def on_oneclick_convert(self, *args, **kwargs):
+        """Handle the One-Click Conversion button press."""
+        # 0) PRE-LAUNCH PHOTOMESH QUEUE
+        self.log_message("[PhotoMesh] Starting/validating Project Queue ...")
+        try:
+            prelaunch_photomesh_queue(log=self.log_message, wait_seconds=90)
+            self.log_message("[PhotoMesh] Queue is live.")
+        except Exception as e:
+            self.log_message(f"[PhotoMesh] {e} (continuing to image selection)")
+
+        # 1) IMAGERY + PROJECT SELECTION
+        if not hasattr(self, 'image_folder_paths') or not self.image_folder_paths:
+            self.select_imagery()
+            if not hasattr(self, 'image_folder_paths') or not self.image_folder_paths:
+                return
+
+        project_name = prompt_project_name(self)
+        if not project_name:
+            messagebox.showwarning("Missing Name", "Project name is required.", parent=self)
+            return
+
+        project_output_dir = self.get_projects_root_default()
+        if not project_output_dir:
+            project_output_dir = filedialog.askdirectory(title="Select Project Output Folder", parent=self)
+            if not project_output_dir:
+                messagebox.showwarning("Missing Folder", "Project output folder is required.", parent=self)
+                return
+            self.set_projects_root_default(project_output_dir)
+
+        # 2) QUEUE THE BUILD
+        try:
+            queue_build_from_gui_selection(
+                project_name=project_name,
+                project_output_dir=project_output_dir,
+                image_folders=self.image_folder_paths,
+                log=self.log_message,
+            )
+            self.log_message("Queued build via Project Queue.")
+        except Exception as e:
+            messagebox.showerror("PhotoMesh Queue Error", str(e), parent=self)
+            return
 
     def on_launch_reality_mesh(self):
      self.launch_reality_mesh_to_vbs4()
@@ -3487,24 +3535,16 @@ class VBS4Panel(tk.Frame):
 
         image_folders = self.image_folder_paths
 
-        try:
-            working_unc = config.get("Paths", "NetworkWorkingFolder", fallback="").strip()
-            if not working_unc:
-                working_unc = config.get("Offline", "network_working_folder", fallback="").strip()
-        except Exception:
-            working_unc = ""
-
         preset_src = None  # optional preset path or None
 
         try:
             self.log_message("Submitting project to PhotoMesh queue…")
             queue_build_from_gui_selection(
                 project_name=project_name,
-                project_dir=project_dir,
+                project_output_dir=project_dir,
                 image_folders=image_folders,
-                working_folder=working_unc,
-                preset_src=preset_src,
                 log=self.log_message if hasattr(self, "log_message") else print,
+                preset_src=preset_src,
             )
             self.log_message(f"Queued project '{project_name}' and started build.")
         except Exception as e:

--- a/PythonPorjects/photomesh_launcher.py
+++ b/PythonPorjects/photomesh_launcher.py
@@ -28,6 +28,7 @@ import os
 import subprocess
 import sys
 import time
+import http.client
 from typing import List
 
 try:  # pragma: no cover - optional dependency
@@ -463,11 +464,21 @@ def poll_queue_until_done(
 
 def _is_queue_up() -> bool:
     """Return True if the Project Queue REST API responds."""
-    if not requests:
-        return False
+    # 1) fast path with requests when available
+    if requests:
+        try:
+            r = requests.get(QUEUE_API_URL + "version", timeout=1.5)
+            return r.ok
+        except Exception:
+            return False
+    # 2) stdlib fallback (no external deps)
     try:
-        r = requests.get(QUEUE_API_URL + "version", timeout=1.5)
-        return r.ok
+        conn = http.client.HTTPConnection("127.0.0.1", 8087, timeout=1.5)
+        conn.request("GET", "/ProjectQueue/version")
+        resp = conn.getresponse()
+        ok = (200 <= resp.status < 300)
+        conn.close()
+        return ok
     except Exception:
         return False
 
@@ -491,7 +502,28 @@ def wait_for_queue_ready(timeout_sec: int = QUEUE_READY_TIMEOUT_SEC, log=print) 
             log("Project Queue REST is ready.")
             return
         time.sleep(QUEUE_POLL_INTERVAL_SEC)
-    raise TimeoutError("PhotoMesh Project Queue did not become ready in time.")
+    log("⚠️  Project Queue did not respond in time; continuing anyway.")
+
+
+def ensure_photomesh_queue_running(
+    log=print,
+    wait_seconds: int = QUEUE_READY_TIMEOUT_SEC,
+    run_as_admin: bool = False,
+) -> None:
+    """Launch PhotoMesh and wait for the Project Queue REST API."""
+    # ``run_as_admin`` retained for API compatibility but ignored; launching
+    # PhotoMesh does not require elevation for the queue to become available.
+    launch_photomesh_if_needed(log=log)
+    wait_for_queue_ready(timeout_sec=wait_seconds, log=log)
+
+
+# --- NEW: simple prelaunch wrapper used by the GUI ---
+def prelaunch_photomesh_queue(log=print, wait_seconds: int = 90) -> None:
+    """
+    Ensure PhotoMesh is running and the Project Queue REST endpoint responds
+    before the GUI opens any file dialogs. No elevation required.
+    """
+    ensure_photomesh_queue_running(log=log, wait_seconds=wait_seconds, run_as_admin=False)
 
 def make_source_path_from_folders(folders: List[str]) -> List[dict]:
     """
@@ -610,18 +642,16 @@ def install_engine_preset(pmpreset_path: str, log=print) -> str:
 
 def queue_build_from_gui_selection(
     project_name: str,
-    project_dir: str,
+    project_output_dir: str,
     image_folders: List[str],
-    working_folder: str,
-    preset_src: str | None = None,
     log=print,
+    preset_src: str | None = None,
 ) -> None:
     """
-    Do not change GUI. Ensure engine queue is up, build payload from current selection,
-    submit, and start build.
+    Ensure PhotoMesh's Project Queue is running, build payload from the current
+    GUI selection, submit, and start the build.
     """
-    launch_photomesh_if_needed(log=log)
-    wait_for_queue_ready(log=log)
+    ensure_photomesh_queue_running(log=log, wait_seconds=QUEUE_READY_TIMEOUT_SEC, run_as_admin=False)
 
     src = make_source_path_from_folders(image_folders)
     if not src:
@@ -631,7 +661,10 @@ def queue_build_from_gui_selection(
     if preset_src:
         preset_name = install_engine_preset(preset_src, log=log)
 
-    payload = build_queue_payload(project_name, project_dir, src, working_folder, preset_name)
+    o = get_offline_cfg()
+    working_folder = resolve_network_working_folder_from_cfg(o)
+
+    payload = build_queue_payload(project_name, project_output_dir, src, working_folder, preset_name)
     submit_project_to_queue(payload, log=log)
     start_build(log=log)
 # endregion
@@ -670,6 +703,8 @@ __all__ = [
     "find_wizard_exe",
     "poll_queue_until_done",
     "queue_build_from_gui_selection",
+    "ensure_photomesh_queue_running",
+    "prelaunch_photomesh_queue",
     "launch_photomesh_if_needed",
     "wait_for_queue_ready",
     "make_source_path_from_folders",


### PR DESCRIPTION
## Summary
- Add fallback HTTP check so PhotoMesh prelaunch works without `requests` and logs a warning instead of raising if the queue never responds.
- Log and continue from the GUI when prelaunch fails, letting imagery/project pickers open regardless of queue status.

## Testing
- `python -m py_compile PythonPorjects/photomesh_launcher.py`
- `python -m py_compile PythonPorjects/STE_Toolkit.py`


------
https://chatgpt.com/codex/tasks/task_e_68b99dcb868c83228ffb905f1c083f89

## Summary by Sourcery

Pre-launch the PhotoMesh queue in the One-Click workflow using a new wrapper and fallback HTTP check, convert queue timeouts into warnings so the GUI continues, and refactor queue submission calls for consistent parameter usage and config-based working folder resolution

New Features:
- Add ensure_photomesh_queue_running and prelaunch_photomesh_queue functions to start and verify the PhotoMesh queue before GUI actions

Enhancements:
- Rename project_dir to project_output_dir and consolidate network working folder resolution in queue_build_from_gui_selection
- Introduce get_projects_root_default and set_projects_root_default helpers for persisting project root