### PR TITLE
Ensure PhotoMesh Wizard defaults enable OBJ output

### DIFF
--- a/PythonPorjects/STE_Toolkit.py
+++ b/PythonPorjects/STE_Toolkit.py
@@ -4696,6 +4696,8 @@ if __name__ == "__main__":
         print("STE Toolkit is already running.")
         sys.exit(0)
     start_command_server()
+    # Ensure PhotoMesh Wizard defaults include OBJ output at startup
+    apply_minimal_wizard_defaults()
     app = MainApp()
     if config['Fusers'].getboolean('fuser_computer', False):
         update_fuser_shared_path()


### PR DESCRIPTION
## Summary
- Call `apply_minimal_wizard_defaults()` during toolkit startup to guarantee OBJ export defaults

## Testing
- `python -m py_compile PythonPorjects/STE_Toolkit.py`


------
https://chatgpt.com/codex/tasks/task_e_68b9b4ebd5cc8322a8e313aa2478e5cb

## Summary by Sourcery

Enhancements:
- Invoke apply_minimal_wizard_defaults at toolkit startup to ensure OBJ output defaults in the PhotoMesh Wizard.