### PR TITLE
Ensure PhotoMesh runs with OBJ export preset

### DIFF
--- a/PythonPorjects/STEPRESET.PMPreset
+++ b/PythonPorjects/STEPRESET.PMPreset
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Preset>
+  <OutputProducts>
+    <Model3D>true</Model3D>
+  </OutputProducts>
+  <Model3DFormats>
+    <OBJ>true</OBJ>
+  </Model3DFormats>
+</Preset>

--- a/PythonPorjects/STE_Toolkit.py
+++ b/PythonPorjects/STE_Toolkit.py
@@ -71,6 +71,10 @@ from photomesh_launcher import (
     _read_photomesh_host,
     apply_minimal_wizard_defaults,
     launch_wizard_new_project,
+    install_pmpreset,
+    list_output_settings_xml,
+    assert_obj_enabled,
+    assert_preset_settings_name,
 )
 from collections import OrderedDict
 import time
@@ -178,8 +182,8 @@ def _iter_build_outputs(build_root: str):
             continue
 
 
-def wait_for_obj_or_xyz(build_root: str, timeout_sec: int = 8*3600, poll_sec: int = 10, log=print) -> str | None:
-    """Block until an OBJ export (or offset.xyz sidecar) exists. Return the folder that holds it."""
+def wait_for_obj(build_root: str, timeout_sec: int = 8*3600, poll_sec: int = 10, log=print) -> str | None:
+    """Block until an OBJ export exists. Return the folder that holds it."""
     start = time.time()
     while time.time() - start < timeout_sec:
         for odir in _iter_build_outputs(build_root):
@@ -189,11 +193,6 @@ def wait_for_obj_or_xyz(build_root: str, timeout_sec: int = 8*3600, poll_sec: in
                     if any(fn.lower().endswith(".obj") for fn in files):
                         log(f"[watch] OBJ found: {obj_dir}")
                         return obj_dir
-            if any(os.path.isfile(os.path.join(odir, name)) for name in ("Output-WKT.txt", "Output-WKT_Models.txt")):
-                xyz = next((f for f in os.listdir(odir) if f.lower().endswith("_offset.xyz")), "")
-                if xyz:
-                    log(f"[watch] offset.xyz found: {os.path.join(odir, xyz)}")
-                    return odir
         time.sleep(poll_sec)
     return None
 
@@ -3549,6 +3548,8 @@ class VBS4Panel(tk.Frame):
         try:
             apply_minimal_wizard_defaults()
             enforce_photomesh_settings()
+            pmpreset_path = os.path.join(os.path.dirname(__file__), "STEPRESET.PMPreset")
+            install_pmpreset(pmpreset_path, name="STEPRESET")
             proc = launch_wizard_new_project(
                 project_name=project_name,
                 project_path=project_dir,
@@ -3557,8 +3558,38 @@ class VBS4Panel(tk.Frame):
             )
             if hasattr(self, "detach_wizard_on_photomesh_start_by_pid") and proc:
                 self.detach_wizard_on_photomesh_start_by_pid(proc.pid, project_dir)
-            self.log_message("PhotoMesh Wizard launched with --overrideSettings (no preset).")
+            self.log_message(
+                "PhotoMesh Wizard launched with preset STEPRESET and --overrideSettings."
+            )
             self.start_progress_monitor(project_dir)
+
+            ps_path = os.path.join(project_dir, "PresetSettings.xml")
+            if os.path.isfile(ps_path):
+                try:
+                    assert_preset_settings_name(project_dir, "STEPRESET")
+                    self.log_message("\u2705 Preset STEPRESET confirmed in PresetSettings.xml")
+                    self.preset_check_pending = False
+                except RuntimeError:
+                    raise
+            else:
+                self.log_message(
+                    "\u26a0\ufe0f PresetSettings.xml not found yet; will check again after build starts."
+                )
+                self.preset_check_pending = True
+
+            xmls = list_output_settings_xml(project_dir)
+            if xmls:
+                try:
+                    assert_obj_enabled(xmls[0])
+                    self.log_message("\u2705 OBJ detected in Output-Settings.xml")
+                    self.obj_check_pending = False
+                except RuntimeError:
+                    raise
+            else:
+                self.log_message(
+                    "\u26a0\ufe0f No Output-Settings.xml found yet; will check again after build starts."
+                )
+                self.obj_check_pending = True
         except Exception as e:
             error_message = f"Failed to start PhotoMesh Wizard.\nError: {str(e)}"
             self.log_message(error_message)
@@ -3617,25 +3648,10 @@ class VBS4Panel(tk.Frame):
 
         def _pipeline():
             try:
-                self.log_message("Waiting for PhotoMesh to finish (TerraExplorer or OBJ/XYZ).")
-                got_te = [False]
-                result = [None]
-
-                def _wait_te():
-                    got_te[0] = wait_for_terraexplorer_start(log=self.log_message)
-
-                def _wait_obj():
-                    result[0] = wait_for_obj_or_xyz(self.last_build_dir, log=self.log_message)
-
-                t1 = threading.Thread(target=_wait_te, daemon=True)
-                t2 = threading.Thread(target=_wait_obj, daemon=True)
-                t1.start(); t2.start()
-
-                for t in itertools.cycle((t1, t2)):
-                    t.join(timeout=0.5)
-                    if not t1.is_alive() or not t2.is_alive():
-                        break
-
+                self.log_message("Waiting for PhotoMesh to finish (OBJ).")
+                result = wait_for_obj(self.last_build_dir, log=self.log_message)
+                if not result:
+                    raise RuntimeError("Timed out waiting for OBJ export.")
                 self.log_message("Build completion detected.")
             except Exception as exc:
                 self.log_message(f"Failed while waiting for completion: {exc}")
@@ -3825,6 +3841,7 @@ class VBS4Panel(tk.Frame):
     # ------------------------------------------------------------------
     def start_progress_monitor(self, project_path: str):
         """Begin monitoring PhotoMesh render logs under *project_path*."""
+        self.project_root = project_path
         self.project_log_folder = os.path.join(project_path, "Build_1", "out", "Log")
         self.work_folder = os.path.join(project_path, "Build_1", "out", "Work")
         self.last_build_dir = os.path.join(project_path, "Build_1", "out")
@@ -3836,6 +3853,28 @@ class VBS4Panel(tk.Frame):
         self.progress_job = self.after(2000, self.update_render_progress)
 
     def update_render_progress(self):
+        if getattr(self, "preset_check_pending", False) and getattr(self, "project_root", ""):
+            ps_path = os.path.join(self.project_root, "PresetSettings.xml")
+            if os.path.isfile(ps_path):
+                try:
+                    assert_preset_settings_name(self.project_root, "STEPRESET")
+                    self.log_message("\u2705 Preset STEPRESET confirmed in PresetSettings.xml")
+                except RuntimeError as e:
+                    self.log_message(str(e))
+                    messagebox.showerror("Preset Not Enabled", str(e), parent=self)
+                self.preset_check_pending = False
+
+        if getattr(self, "obj_check_pending", False) and getattr(self, "project_root", ""):
+            xmls = list_output_settings_xml(self.project_root)
+            if xmls:
+                try:
+                    assert_obj_enabled(xmls[0])
+                    self.log_message("\u2705 OBJ detected in Output-Settings.xml")
+                except RuntimeError as e:
+                    self.log_message(str(e))
+                    messagebox.showerror("OBJ Not Enabled", str(e), parent=self)
+                self.obj_check_pending = False
+
         paths = []
         if self.project_log_folder and os.path.isdir(self.project_log_folder):
             paths += glob.glob(os.path.join(self.project_log_folder, "Out*.log"))

--- a/PythonPorjects/photomesh_launcher.py
+++ b/PythonPorjects/photomesh_launcher.py
@@ -11,11 +11,12 @@
 #   5) Utilities (pure helpers, no I/O)
 #   6) File I/O & JSON helpers
 #   7) Wizard Config (read/patch install config)
-#   8) Network / UNC resolution
-#   9) Launch / CLI argument builders
-#  10) GUI / Tkinter handlers
-#  11) Logging & Error handling
-#  12) Main entry point
+#   8) Wizard Presets & Output validation
+#   9) Network / UNC resolution
+#  10) Launch / CLI argument builders
+#  11) GUI / Tkinter handlers
+#  12) Logging & Error handling
+#  13) Main entry point
 # =============================================================================
 
 # region Imports
@@ -25,9 +26,12 @@ import configparser
 import ctypes
 import json
 import os
+import shutil
 import subprocess
 import sys
 import time
+import xml.etree.ElementTree as ET
+from pathlib import Path
 from typing import Iterable
 
 try:  # pragma: no cover - optional dependency
@@ -166,6 +170,64 @@ def apply_minimal_wizard_defaults() -> None:
         # m3d["LAS"] = True
         _save_json(cfg_path, cfg)
         print(f"[Wizard] Ensured Model3D/OBJ/3DML enabled -> {cfg_path}")
+# endregion
+
+# region Wizard Presets & Output validation
+
+def _pm_presets_dir() -> str:
+    """Return the PhotoMesh Wizard presets directory."""
+    appdata = os.environ.get("APPDATA", "")
+    return os.path.join(appdata, "Skyline", "PhotoMesh", "Presets")
+
+
+def install_pmpreset(src_path: str, name: str = "STEPRESET") -> str:
+    """Copy *src_path* into the presets dir with a stable *name*."""
+    dst_dir = _pm_presets_dir()
+    os.makedirs(dst_dir, exist_ok=True)
+    dst = os.path.join(dst_dir, f"{name}.PMPreset")
+    shutil.copy2(src_path, dst)
+    return dst
+
+
+def list_output_settings_xml(project_root: str) -> list[str]:
+    """Return Output-Settings.xml paths under Build_* folders (newest first)."""
+    hits: list[tuple[float, str]] = []
+    for b in Path(project_root).glob("Build_*"):
+        for od in b.glob("outputBuild_*"):
+            f = od / "Output-Settings.xml"
+            if f.is_file():
+                hits.append((f.stat().st_mtime, str(f)))
+    hits.sort(reverse=True, key=lambda t: t[0])
+    return [p for _, p in hits]
+
+
+def assert_obj_enabled(output_settings_xml: str) -> None:
+    """Raise RuntimeError if *output_settings_xml* lacks OBJ export."""
+    tree = ET.parse(output_settings_xml)
+    root = tree.getroot()
+    text = ET.tostring(root, encoding="unicode").lower()
+    want = ("model3d" in text) and ("obj" in text)
+    if not want:
+        raise RuntimeError(
+            f"OBJ not enabled according to {output_settings_xml}. "
+            "Please ensure your preset enables OutputProducts->3D Model and Model3DFormats->OBJ."
+        )
+
+
+def assert_preset_settings_name(project_root: str, name: str = "STEPRESET") -> None:
+    """Raise RuntimeError if PresetSettings.xml omits *name*.
+
+    If ``PresetSettings.xml`` is missing under *project_root*, no error is raised.
+    """
+    ps = Path(project_root) / "PresetSettings.xml"
+    if not ps.is_file():
+        return
+    text = ps.read_text(encoding="utf-8", errors="ignore").lower()
+    if name.lower() not in text:
+        raise RuntimeError(
+            f"PresetSettings.xml in {project_root} does not mention preset '{name}'."
+        )
+
 # endregion
 
 # region Network / UNC resolution
@@ -340,8 +402,7 @@ def launch_wizard_new_project(
     project_name: str, project_path: str, folders, log=print
 ) -> subprocess.Popen:
     """
-    Launch Wizard for a new project.
-    - No presets passed.
+    Launch Wizard for a new project using preset ``STEPRESET``.
     - Uses --overrideSettings so Build Settings honor our defaults.
     - *folders*: iterable of image folder paths.
     """
@@ -351,8 +412,10 @@ def launch_wizard_new_project(
         project_name,
         "--projectPath",
         project_path,
-        "--autostart",
+        "--preset",
+        "STEPRESET",
         "--overrideSettings",
+        "--autostart",
     ]
     for f in folders or []:
         args += ["--folder", f]
@@ -575,6 +638,10 @@ __all__ = [
     "open_in_explorer",
     "resolve_network_working_folder_from_cfg",
     "enforce_photomesh_settings",
+    "install_pmpreset",
+    "list_output_settings_xml",
+    "assert_obj_enabled",
+    "assert_preset_settings_name",
     "find_wizard_exe",
     "submit_queue_build",
     "poll_queue_until_done",


### PR DESCRIPTION
## Summary
- install STEPRESET preset and validate preset name via PresetSettings.xml
- launch PhotoMesh Wizard with STEPRESET and verify OBJ export configuration
- wait for OBJ files before sending projects to Reality Mesh

## Testing
- `python -m py_compile PythonPorjects/photomesh_launcher.py PythonPorjects/STE_Toolkit.py`


------
https://chatgpt.com/codex/tasks/task_e_68ba001125c883229684f0d5ad93b702

## Summary by Sourcery

Ensure PhotoMesh runs with the STEPRESET preset by installing it, passing it to the wizard, and validating OBJ export settings throughout the build process.

New Features:
- Install and launch PhotoMesh wizard with a dedicated STEPRESET preset
- Validate that PresetSettings.xml references STEPRESET and that OBJ export is enabled via Output-Settings.xml

Enhancements:
- Streamline build completion logic to wait solely for OBJ export
- Add periodic checks in the progress monitor for pending preset and OBJ validation
- Reorganize photomesh_launcher script structure to include a presets and output validation section

Chores:
- Add STEPRESET.PMPreset to repository