### PR TITLE
Add shared drive mapping and auto discovery

### DIFF
--- a/PythonPorjects/config.ini
+++ b/PythonPorjects/config.ini
@@ -40,3 +40,8 @@ working_fuser_host = KIT1-1
 
 [Paths]
 projects_root =
+
+[SharedDrive]
+preferred_mode = UNC
+drive_letter = M:
+auto_map_on_save = True

--- a/PythonPorjects/update_photomesh_config.py
+++ b/PythonPorjects/update_photomesh_config.py
@@ -21,6 +21,16 @@
 # region Imports
 import json
 import os
+import sys
+
+BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+if BASE_DIR not in sys.path:
+    sys.path.append(BASE_DIR)
+
+from photomesh_launcher import (
+    get_offline_cfg,
+    resolve_network_working_folder_from_cfg,
+)
 # endregion
 
 # region Constants & Configuration
@@ -75,6 +85,10 @@ def update_config(path: str) -> None:
     fmts["OBJ"] = True
     # Optional:
     # fmts["LAS"] = True
+
+    config["NetworkWorkingFolder"] = resolve_network_working_folder_from_cfg(
+        get_offline_cfg()
+    )
 
     try:
         _save_config(path, config)


### PR DESCRIPTION
## Summary
- add SMB share discovery and drive mapping helpers
- extend settings panel with preferred access mode and drive controls
- ensure wizard config uses current UNC network working folder

## Testing
- `python -m py_compile PythonPorjects/photomesh_launcher.py PythonPorjects/STE_Toolkit.py PythonPorjects/update_photomesh_config.py`


------
https://chatgpt.com/codex/tasks/task_e_68bafd43d0dc8322aa939df8d353708f

## Summary by Sourcery

Add shared drive discovery and mapping functionality, enhance the settings UI to configure and auto-map network drives, persist drive preferences in configuration, and ensure the wizard uses the resolved UNC working folder

New Features:
- Add functions for SMB share discovery (list_remote_shares) and selection (probe_best_mesh_share)
- Implement drive mapping utilities (map_drive, unmap_drive, current_mapping) and path resolution (resolve_shared_access_path)
- Extend settings panel with access mode radio buttons, drive letter input, auto-map on save checkbox, and auto-find share button
- Persist SharedDrive preferences (preferred_mode, drive_letter, auto_map_on_save) in config.ini and auto-map on save

Enhancements:
- Update update_photomesh_config to use the current UNC network working folder for wizard configuration