### PR TITLE
feat: centralize host settings in toolkit

### DIFF
--- a/PythonPorjects/photomesh_launcher.py
+++ b/PythonPorjects/photomesh_launcher.py
@@ -232,7 +232,11 @@ def assert_preset_settings_name(project_root: str, name: str = "STEPRESET") -> N
 
 # region Network / UNC resolution
 def _read_photomesh_host() -> str:
-    """Resolve the PhotoMesh host from config.ini settings."""
+    """Resolve the PhotoMesh host from config.ini settings.
+
+    The STE toolkit's :func:`set_host` writes the selected host name to all
+    legacy keys checked here, keeping older config readers compatible.
+    """
     try:
         config.read(CONFIG_PATH)
         if config.has_section("Offline"):
@@ -275,7 +279,11 @@ def _is_offline_enabled() -> bool:
 
 
 def get_offline_cfg() -> dict:
-    """Return Offline section settings with defaults applied."""
+    """Return Offline section settings with defaults applied.
+
+    The ``host_name`` value is maintained by ``STE_Toolkit.set_host`` so that
+    older tools reading this config continue to work without changes.
+    """
     try:
         config.read(CONFIG_PATH)
     except Exception:


### PR DESCRIPTION
## Summary
- consolidate host setter to populate Offline, Network, and Fusers sections
- remove duplicate Offline host name field and use single host PC name input
- update fuser toggle and config helpers to reference unified host

## Testing
- `python -m py_compile PythonPorjects/STE_Toolkit.py PythonPorjects/photomesh_launcher.py`
- `python - <<'PY'
import ast,configparser,shutil,os,pathlib
src=pathlib.Path('PythonPorjects/STE_Toolkit.py').read_text()
module=ast.parse(src)
set_func=next(n for n in module.body if isinstance(n,ast.FunctionDef) and n.name=='set_host')
code=compile(ast.Module(body=[set_func],type_ignores=[]),'set_host_extract','exec')
orig='PythonPorjects/config.ini';tmp='PythonPorjects/config_test.ini';shutil.copy2(orig,tmp)
ns={};exec('import configparser,os\nCONFIG_PATH="'+tmp+'"\nconfig=configparser.ConfigParser()\nconfig.read(CONFIG_PATH)',ns)
exec(code,ns);ns['set_host']('TESTHOST')
cp=configparser.ConfigParser();cp.read(tmp)
print('Offline.host_name',cp.get('Offline','host_name'))
print('Offline.working_fuser_host',cp.get('Offline','working_fuser_host'))
print('Network.host',cp.get('Network','host'))
print('Fusers.working_folder_host',cp.get('Fusers','working_folder_host'))
os.remove(tmp)
PY`

------
https://chatgpt.com/codex/tasks/task_e_68bb0e008bf8832288399d9e3f879bbf

## Summary by Sourcery

Centralize host PC name management by consolidating the host setter to update all legacy config keys, removing redundant host name inputs, and updating the UI and fuser logic to reference a single source of truth.

Enhancements:
- Extend set_host to persist the host value across Offline.host_name, Offline.working_fuser_host, Network.host, and Fusers.working_folder_host in the config file
- Update Fusers toggle handler to use get_host() for working_folder_host instead of prompting the user
- Rename the network GUI label to "Host PC Name" and remove the redundant offline Host Name entry, leaving only the Host IP input
- Synchronize offline settings saving and auto-find share logic to use the unified get_host() value for host_name
- Add compatibility notes in photomesh_launcher docstrings about set_host writing to legacy config keys