### PR TITLE
Use shortcut presence to validate Reality Mesh install folder

### DIFF
--- a/PythonPorjects/photomesh_launcher.py
+++ b/PythonPorjects/photomesh_launcher.py
@@ -74,6 +74,8 @@ OFFLINE_ACCESS_HINT = (
     "read/write permissions, and if name resolution fails, enable use_ip_unc or add "
     "host_name to C:\\Windows\\System32\\drivers\\etc\\hosts."
 )
+RM_LNK_NAME = "Reality Mesh to VBS4.lnk"
+RM_INSTALL_SUBDIRS = ["RealityMeshInstall", "ReailityMeshInstall"]
 # endregion
 
 # region Paths & Environment
@@ -152,6 +154,73 @@ def set_projects_root(path: str) -> None:
         config.add_section("Paths")
     config.set("Paths", "projects_root", path)
     _save_config()
+# endregion
+
+# region Reality Mesh helpers
+
+def is_valid_rm_local_root(root: str) -> bool:
+    """
+    Return True if *root* exists and contains the 'Reality Mesh to VBS4.lnk'
+    either directly or somewhere beneath it. No 'Datatarget.txt' check.
+    """
+    if not root:
+        return False
+    root = os.path.abspath(root)
+    if not os.path.isdir(root):
+        return False
+
+    direct = os.path.join(root, RM_LNK_NAME)
+    if os.path.isfile(direct):
+        return True
+
+    for sub in RM_INSTALL_SUBDIRS:
+        p = os.path.join(root, sub, RM_LNK_NAME)
+        if os.path.isfile(p):
+            return True
+
+    target_lower = RM_LNK_NAME.lower()
+    try:
+        for dp, _ds, fs in os.walk(root):
+            for f in fs:
+                if f.lower() == target_lower:
+                    return True
+    except Exception:
+        pass
+
+    return False
+
+
+def find_local_rm_shortcut(root: str) -> str:
+    """
+    Return the full path to 'Reality Mesh to VBS4.lnk' under *root*.
+    Searches direct, common subfolders, then recursively.
+    """
+    if not root:
+        return ''
+    root = os.path.abspath(root)
+    if not os.path.isdir(root):
+        return ''
+
+    direct = os.path.join(root, RM_LNK_NAME)
+    if os.path.isfile(direct):
+        return direct
+
+    for sub in RM_INSTALL_SUBDIRS:
+        p = os.path.join(root, sub, RM_LNK_NAME)
+        if os.path.isfile(p):
+            return os.path.normpath(p)
+
+    target_lower = RM_LNK_NAME.lower()
+    try:
+        for dp, _ds, fs in os.walk(root):
+            for f in fs:
+                if f.lower() == target_lower:
+                    return os.path.normpath(os.path.join(dp, f))
+    except Exception:
+        pass
+
+    return ''
+
 # endregion
 
 # region Wizard Config
@@ -838,6 +907,10 @@ __all__ = [
     "find_wizard_exe",
     "submit_queue_build",
     "poll_queue_until_done",
+    "RM_LNK_NAME",
+    "RM_INSTALL_SUBDIRS",
+    "is_valid_rm_local_root",
+    "find_local_rm_shortcut",
 ]
 
 # =============================================================================


### PR DESCRIPTION
## Summary
- Replace Datatarget.txt sentinel check with search for `Reality Mesh to VBS4.lnk` under the selected folder or its subfolders.
- Update Settings panel to "Reality Mesh Install Folder" with validation and messages based on the shortcut.
- Prefer local shortcut when launching Reality Mesh, falling back to UNC paths if absent.

## Testing
- `python -m py_compile PythonPorjects/photomesh_launcher.py PythonPorjects/STE_Toolkit.py`

------
https://chatgpt.com/codex/tasks/task_e_68bb1bcad0648322a116312a9a31c52a

## Summary by Sourcery

Replace the old Datatarget.txt validation with detection of the ‘Reality Mesh to VBS4.lnk’ shortcut for install folder validation and launch, and update related UI labels and messages.

Enhancements:
- Validate Reality Mesh install folder by searching for the ‘Reality Mesh to VBS4.lnk’ shortcut (direct, in subfolders, or recursively) instead of checking for Datatarget.txt.
- Extract RM_LNK_NAME and RM_INSTALL_SUBDIRS constants and helper functions into photomesh_launcher for consistent shortcut detection.
- Rename Settings panel entry to “Reality Mesh Install Folder” and update error/info messages and status labels to reference the shortcut-based validation.
- Adjust launch_reality_mesh_to_vbs4 logic to prefer local shortcuts and provide updated diagnostic messages based on the new validation