### PR TITLE
feat: improve PhotoMesh Wizard discovery

### DIFF
--- a/PythonPorjects/update_photomesh_config.py
+++ b/PythonPorjects/update_photomesh_config.py
@@ -35,7 +35,10 @@ from photomesh_launcher import (
 
 # region Constants & Configuration
 # PhotoMesh Wizard install config (read by Wizard at startup)
-CONFIG_PATH = r"C:\\Program Files\\Skyline\\PhotoMeshWizard\\config.json"
+CONFIG_CANDIDATES = [
+    r"C:\\Program Files\\Skyline\\PhotoMeshWizard\\config.json",
+    r"C:\\Program Files\\Skyline\\PhotoMesh\\Tools\\PhotomeshWizard\\config.json",
+]
 # endregion
 
 # region Paths & Environment
@@ -113,8 +116,21 @@ def update_config(path: str) -> None:
 # endregion
 
 # region Main entry point
+def main() -> None:
+    any_ok = False
+    for path in CONFIG_CANDIDATES:
+        if os.path.isfile(path):
+            update_config(path)
+            any_ok = True
+    if not any_ok:
+        print("❌ PhotoMesh Wizard config.json not found in expected locations.")
+        print(
+            "   Please install Skyline PhotoMesh/Wizard or run the Toolkit once to cache the path."
+        )
+
+
 if __name__ == "__main__":
-    update_config(CONFIG_PATH)
+    main()
 # endregion
 
 # =============================================================================


### PR DESCRIPTION
## Summary
- add comprehensive PhotoMesh Wizard executable discovery and caching
- patch wizard configs based on discovered EXE location
- broaden standalone config updater to search multiple install paths

## Testing
- `python -m py_compile PythonPorjects/photomesh_launcher.py PythonPorjects/update_photomesh_config.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb2d6a5bc4832288ceae2232cf6cf2

## Summary by Sourcery

Improve PhotoMesh Wizard discovery by implementing a multi-stage search for the Wizard executable—including config override, standard and legacy install paths, registry uninstall entries, and recursive scans—and caching the result in config.ini. Dynamically derive config.json locations from the discovered executable, update the standalone config updater to handle multiple candidate paths, and enhance the launch API to leverage the discovery routine, support video inputs, and surface clear errors when the executable is missing.

New Features:
- Add a comprehensive find_wizard_exe routine that searches overrides, Program Files (x64/x86) canonical and legacy subpaths, registry uninstall entries, and recursive Program Files scans, then caches the resolved path in config.ini
- Introduce wizard_config_paths_from_exe to dynamically assemble and patch all relevant Wizard config.json locations based on the discovered executable
- Extend update_photomesh_config script to iterate multiple config.json candidate paths and report when no installation is found
- Revamp launch_wizard_new_project to use the discovery mechanism, support video arguments, enforce autostart, and provide user-friendly errors if the Wizard executable cannot be located