### PR TITLE
Update PhotoMesh Wizard default path and handle preset bundling

### DIFF
--- a/PythonPorjects/STE_Toolkit.py
+++ b/PythonPorjects/STE_Toolkit.py
@@ -103,6 +103,15 @@ try:  # Optional atomic write helper
 except Exception:  # pragma: no cover - helper may not exist
     write_config_atomic = None
 
+# --- Resource path resolver -------------------------------------------------
+def _resource_path(name: str) -> str:
+    """Return absolute path to bundled resource *name*.
+
+    When frozen with PyInstaller, resources live under ``sys._MEIPASS``.
+    """
+    base = getattr(sys, "_MEIPASS", os.path.dirname(__file__))
+    return os.path.join(base, name)
+
 # --- UI dispatch (thread-safe) ---
 _UI_QUEUE = Queue()
 
@@ -3720,8 +3729,11 @@ class VBS4Panel(tk.Frame):
         try:
             apply_offline_settings()            # Wizard NetworkWorkingFolder + fuser shared_path
             update_fuser_shared_path()          # belt and suspenders
-            pmpreset_path = os.path.join(os.path.dirname(__file__), "STEPRESET.PMPreset")
-            install_pmpreset(pmpreset_path, name="STEPRESET")
+            pmpreset_path = _resource_path("STEPRESET.PMPreset")
+            try:
+                install_pmpreset(pmpreset_path, name="STEPRESET", log=self.log_message)
+            except FileNotFoundError:
+                self.log_message("[Preset] STEPRESET.PMPreset not bundled; launching with defaults.")
             proc = launch_wizard_new_project(
                 project_name=project_name,
                 project_path=project_dir,

--- a/PythonPorjects/config.ini
+++ b/PythonPorjects/config.ini
@@ -11,7 +11,7 @@ vbs_map_user = TIFTE
 vbs_map_server = localhost
 vbs_map_port = 4080
 fullscreen = True
-photomesh_wizard_exe = C:\Program Files\Skyline\PhotoMeshWizard\PhotoMeshWizard.exe
+photomesh_wizard_exe = C:\Program Files\Skyline\PhotoMesh\Tools\PhotomeshWizard\PhotoMeshWizard.exe
 
 [Auto-Launch]
 enabled = True

--- a/PythonPorjects/photomesh_launcher.py
+++ b/PythonPorjects/photomesh_launcher.py
@@ -50,20 +50,20 @@ except Exception:  # pragma: no cover - headless/test environments
 
 # region Constants & Configuration
 # Authoritative Wizard locations
-WIZARD_DIR = r"C:\\Program Files\\Skyline\\PhotoMeshWizard"
+WIZARD_DIR = r"C:\\Program Files\\Skyline\\PhotoMesh\\Tools\\PhotomeshWizard"
 WIZARD_EXE = rf"{WIZARD_DIR}\\PhotoMeshWizard.exe"
 
 # PhotoMesh Wizard install config (read by Wizard at startup)
 WIZ_CFG_PATHS = [
-    r"C:\\Program Files\\Skyline\\PhotoMeshWizard\\config.json",
     r"C:\\Program Files\\Skyline\\PhotoMesh\\Tools\\PhotomeshWizard\\config.json",
+    r"C:\\Program Files\\Skyline\\PhotoMeshWizard\\config.json",
 ]
 
 # Accept both modern and legacy Wizard executables / locations
 WIZARD_CANDIDATE_NAMES = ("PhotoMeshWizard.exe", "WizardGUI.exe")
 WIZARD_CANDIDATE_SUBPATHS = (
-    r"Skyline\PhotoMeshWizard",
     r"Skyline\PhotoMesh\Tools\PhotomeshWizard",
+    r"Skyline\PhotoMeshWizard",
 )
 
 
@@ -387,12 +387,23 @@ def _pm_presets_dir() -> str:
     return os.path.join(appdata, "Skyline", "PhotoMesh", "Presets")
 
 
-def install_pmpreset(src_path: str, name: str = "STEPRESET") -> str:
-    """Copy *src_path* into the presets dir with a stable *name*."""
+def install_pmpreset(src_path: str, name: str = "STEPRESET", log=print) -> str:
+    """Copy *src_path* into the presets dir with a stable *name*.
+
+    Parameters
+    ----------
+    src_path:
+        Source preset file path.
+    name:
+        Base name for the installed preset (extension will be .PMPreset).
+    log:
+        Logging function used to report the destination path.
+    """
     dst_dir = _pm_presets_dir()
     os.makedirs(dst_dir, exist_ok=True)
     dst = os.path.join(dst_dir, f"{name}.PMPreset")
     shutil.copy2(src_path, dst)
+    log(f"[Preset] Installed {name} -> {dst}")
     return dst
 
 
@@ -809,7 +820,7 @@ def launch_wizard_new_project(
         if messagebox:
             messagebox.showerror("PhotoMesh Wizard not found", msg)
         raise FileNotFoundError(msg)
-    args = [exe, "--projectName", project_name, "--projectPath", project_path]
+    args = [exe, "--projectName", project_name, "--projectPath", project_path, "--overrideSettings"]
     for f in folders:
         args += ["--folder", f]
     for v in videos:

--- a/PythonPorjects/update_photomesh_config.py
+++ b/PythonPorjects/update_photomesh_config.py
@@ -36,8 +36,8 @@ from photomesh_launcher import (
 # region Constants & Configuration
 # PhotoMesh Wizard install config (read by Wizard at startup)
 CONFIG_CANDIDATES = [
-    r"C:\\Program Files\\Skyline\\PhotoMeshWizard\\config.json",
     r"C:\\Program Files\\Skyline\\PhotoMesh\\Tools\\PhotomeshWizard\\config.json",
+    r"C:\\Program Files\\Skyline\\PhotoMeshWizard\\config.json",
 ]
 # endregion
 


### PR DESCRIPTION
## Summary
- default PhotoMesh Wizard path now points to `PhotoMesh\Tools\PhotomeshWizard`
- load STEPRESET preset via resource path for packaged builds
- reorder config search paths to favor new install layout
- add logging around preset installation and launch wizard with `--overrideSettings`

## Testing
- `python -m py_compile PythonPorjects/photomesh_launcher.py PythonPorjects/update_photomesh_config.py PythonPorjects/STE_Toolkit.py`


------
https://chatgpt.com/codex/tasks/task_e_68bb3b93bd548322b6b88395283597c8

## Summary by Sourcery

Update PhotoMesh Wizard integration to use the new install layout, support bundled presets in packaged builds, and improve launch logging and settings override

New Features:
- Add resource path resolver to locate bundled resources when frozen with PyInstaller

Enhancements:
- Update default PhotoMesh Wizard path and reorder config search paths to match new PhotoMesh\Tools\PhotomeshWizard layout
- Include --overrideSettings argument when launching the PhotoMesh Wizard
- Install STEPRESET via the resource path with logging and fallback handling for missing bundled presets
- Update config.ini default wizard executable path to the new install location