### PR TITLE
Enforce OBJ-only defaults for PhotoMesh Wizard 1.5.1

### DIFF
--- a/PythonPorjects/STE_Toolkit.py
+++ b/PythonPorjects/STE_Toolkit.py
@@ -69,6 +69,7 @@ from photomesh_launcher import (
     resolve_network_working_folder_from_cfg,
     resolve_shared_access_path,
     enforce_photomesh_settings,
+    enforce_wizard_obj_only_defaults,
     working_share_root,
     working_fuser_unc,
     _read_photomesh_host,
@@ -5055,6 +5056,7 @@ if __name__ == "__main__":
     start_command_server()
     app = MainApp()
     app.after(50, apply_minimal_wizard_defaults)
+    app.after(75, lambda: enforce_wizard_obj_only_defaults(log=app.log_message))
     if config['Fusers'].getboolean('fuser_computer', False):
         app.after(50, update_fuser_shared_path)
     app.after(50, app.panels['VBS4'].update_fuser_state)

--- a/PythonPorjects/photomesh_launcher.py
+++ b/PythonPorjects/photomesh_launcher.py
@@ -377,6 +377,63 @@ def apply_minimal_wizard_defaults() -> None:
         m3d["OBJ"] = True
         _save_json(cfg_path, cfg)
         print(f"[Wizard] Ensured Model3D/OBJ/3DML enabled -> {cfg_path}")
+
+
+def enforce_wizard_obj_only_defaults(log=print) -> None:
+    """
+    Wizard 1.5.1: Force OBJ-only so Output-PivotOrigin.json has real values.
+    Also set NetworkWorkingFolder to the current WorkingFuser UNC.
+    """
+
+    try:
+        offline_cfg = get_offline_cfg()
+        working_unc = resolve_network_working_folder_from_cfg(offline_cfg)
+    except Exception:
+        working_unc = ""
+
+    cfg_paths = [
+        r"C:\\Program Files\\Skyline\\PhotoMesh\\Tools\\PhotomeshWizard\\config.json",
+        r"C:\\Program Files\\Skyline\\PhotoMeshWizard\\config.json",
+    ]
+
+    for base in filter(None, (os.environ.get("ProgramFiles"), os.environ.get("ProgramFiles(x86)"))):
+        p1 = os.path.join(base, r"Skyline\PhotoMesh\Tools\PhotomeshWizard\config.json")
+        p2 = os.path.join(base, r"Skyline\PhotoMeshWizard\config.json")
+        for candidate in (p1, p2):
+            if candidate not in cfg_paths:
+                cfg_paths.append(candidate)
+
+    try:
+        exe_path = find_wizard_exe()
+    except Exception:
+        exe_path = ""
+    if exe_path:
+        for derived in wizard_config_paths_from_exe(exe_path):
+            if derived not in cfg_paths:
+                cfg_paths.append(derived)
+
+    for path in cfg_paths:
+        if not os.path.isfile(path):
+            continue
+        try:
+            cfg = _load_json(path) or {}
+            ui = cfg.setdefault("DefaultPhotoMeshWizardUI", {})
+            ui.setdefault("OutputProducts", {}).update({"Model3D": True})
+            fmts = ui.setdefault("Model3DFormats", {})
+            fmts["OBJ"] = True
+            fmts["3DML"] = False
+            fmts["SLPK"] = False
+            ui.setdefault("VerticalDatum", "Ellipsoid")
+
+            if working_unc:
+                cfg["NetworkWorkingFolder"] = working_unc
+
+            _save_json(path, cfg)
+            log(f"[Wizard 1.5.1] OBJ-only + WorkingFolder set -> {path}")
+        except PermissionError:
+            log(f"[Wizard 1.5.1] No permission to write {path}. Run as Administrator.")
+        except Exception as exc:
+            log(f"[Wizard 1.5.1] Failed updating {path}: {exc}")
 # endregion
 
 # region Wizard Presets & Output validation
@@ -781,23 +838,14 @@ def enforce_photomesh_settings(autostart: bool = True, log=print) -> None:
     unc = resolve_network_working_folder_from_cfg(o)  # \\hostOrIp\share\WorkingFuser
 
     # 3) Ensure folder exists (best effort)
-    try:
-        os.makedirs(unc, exist_ok=True)
-    except Exception as e:  # pragma: no cover - best effort
-        log(f"[Wizard] Cannot create WorkingFuser at {unc}: {e}")
+    if unc:
+        try:
+            os.makedirs(unc, exist_ok=True)
+        except Exception as e:  # pragma: no cover - best effort
+            log(f"[Wizard] Cannot create WorkingFuser at {unc}: {e}")
 
-    # 4) Patch all known Wizard config.json paths
-    exe = find_wizard_exe()
-    for cfg_path in wizard_config_paths_from_exe(exe):
-        cfg = _load_json(cfg_path)
-        if not cfg:
-            continue
-        ui = cfg.setdefault("DefaultPhotoMeshWizardUI", {})
-        ui.setdefault("OutputProducts", {}).update({"Model3D": True})
-        ui.setdefault("Model3DFormats", {}).update({"OBJ": True, "3DML": True})
-        cfg["NetworkWorkingFolder"] = unc
-        _save_json(cfg_path, cfg)
-        log(f"[Wizard] NetworkWorkingFolder -> {unc} ({cfg_path})")
+    # 4) Enforce Wizard OBJ-only defaults and WorkingFuser UNC
+    enforce_wizard_obj_only_defaults(log=log)
 # endregion
 
 # region Launch / CLI argument builders
@@ -809,6 +857,9 @@ def launch_wizard_new_project(
     autostart: bool = True,
     log=print,
 ) -> subprocess.Popen:
+    # Ensure defaults are correct for 1.5.1 before any GUI shows
+    enforce_wizard_obj_only_defaults(log=log)
+
     exe = find_wizard_exe()
     if not exe:
         msg = (
@@ -1034,6 +1085,7 @@ __all__ = [
     "resolve_shared_access_path",
     "resolve_network_working_folder_from_cfg",
     "enforce_photomesh_settings",
+    "enforce_wizard_obj_only_defaults",
     "install_pmpreset",
     "list_output_settings_xml",
     "assert_obj_enabled",

--- a/PythonPorjects/update_photomesh_config.py
+++ b/PythonPorjects/update_photomesh_config.py
@@ -1,7 +1,7 @@
 # =============================================================================
 # Project: VBS4Project
 # File: update_photomesh_config.py
-# Purpose: Apply minimal defaults to PhotoMesh Wizard config
+# Purpose: Enforce OBJ-only defaults and WorkingFuser UNC in Wizard config
 # =============================================================================
 # Table of Contents
 #   1) Imports
@@ -35,9 +35,11 @@ from photomesh_launcher import (
 
 # region Constants & Configuration
 # PhotoMesh Wizard install config (read by Wizard at startup)
-CONFIG_CANDIDATES = [
+CONFIGS = [
     r"C:\\Program Files\\Skyline\\PhotoMesh\\Tools\\PhotomeshWizard\\config.json",
     r"C:\\Program Files\\Skyline\\PhotoMeshWizard\\config.json",
+    r"C:\\Program Files (x86)\\Skyline\\PhotoMesh\\Tools\\PhotomeshWizard\\config.json",
+    r"C:\\Program Files (x86)\\Skyline\\PhotoMeshWizard\\config.json",
 ]
 # endregion
 
@@ -67,40 +69,48 @@ def _save_config(path: str, config: dict) -> None:
 # endregion
 
 # region Wizard Config
-def update_config(path: str) -> None:
-    """Enable 3D model OBJ and 3DML flags in install-level Wizard config."""
+def update_config(path: str) -> bool:
+    """Force OBJ-only defaults and update NetworkWorkingFolder for Wizard 1.5.1."""
     try:
         config = _load_config(path)
     except FileNotFoundError:
-        print(f"❌ File not found: {path}")
-        return
+        return False
     except PermissionError as exc:
-        print(f"❌ Permission denied reading file: {exc}")
-        return
+        print(f"[Wizard 1.5.1] Permission denied reading {path}: {exc}")
+        print("Run this updater as Administrator.")
+        return False
     except json.JSONDecodeError as exc:
-        print(f"❌ Failed to parse JSON: {exc}")
-        return
+        print(f"[Wizard 1.5.1] Failed to parse {path}: {exc}")
+        return False
 
     ui = config.setdefault("DefaultPhotoMeshWizardUI", {})
     ui.setdefault("OutputProducts", {}).update({"Model3D": True})
     fmts = ui.setdefault("Model3DFormats", {})
-    fmts["3DML"] = True
     fmts["OBJ"] = True
-    # Optional:
-    # fmts["LAS"] = True
+    fmts["3DML"] = False
+    fmts["SLPK"] = False
+    ui.setdefault("VerticalDatum", "Ellipsoid")
 
-    config["NetworkWorkingFolder"] = resolve_network_working_folder_from_cfg(
-        get_offline_cfg()
-    )
+    try:
+        config["NetworkWorkingFolder"] = resolve_network_working_folder_from_cfg(
+            get_offline_cfg()
+        )
+    except Exception:
+        pass
 
     try:
         _save_config(path, config)
-        print("✅ config.json updated successfully.")
-    except PermissionError as exc:
-        print(f"❌ Permission denied writing file: {exc}")
-        print("Please run this script as Administrator.")
+    except PermissionError:
+        print(
+            f"[Wizard 1.5.1] Permission denied writing {path}. Run as Administrator."
+        )
+        return False
     except Exception as exc:
-        print(f"❌ Failed to update config: {exc}")
+        print(f"[Wizard 1.5.1] Failed updating {path}: {exc}")
+        return False
+
+    print(f"[Wizard 1.5.1] Updated -> {path}")
+    return True
 # endregion
 
 # region Network / UNC resolution
@@ -118,15 +128,13 @@ def update_config(path: str) -> None:
 # region Main entry point
 def main() -> None:
     any_ok = False
-    for path in CONFIG_CANDIDATES:
-        if os.path.isfile(path):
-            update_config(path)
+    for path in CONFIGS:
+        if not os.path.isfile(path):
+            continue
+        if update_config(path):
             any_ok = True
     if not any_ok:
-        print("❌ PhotoMesh Wizard config.json not found in expected locations.")
-        print(
-            "   Please install Skyline PhotoMesh/Wizard or run the Toolkit once to cache the path."
-        )
+        print("No PhotoMesh Wizard config.json found in standard locations.")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add an OBJ-only config enforcer that updates all detected Photomesh Wizard installs and WorkingFuser UNC
- invoke the enforcer from toolkit startup, offline settings, and before each Wizard launch to keep defaults consistent
- extend the standalone config updater to cover x86 installs, enforce OBJ-only defaults, and surface permission issues

## Testing
- python -m compileall PythonPorjects/photomesh_launcher.py PythonPorjects/update_photomesh_config.py PythonPorjects/STE_Toolkit.py

------
https://chatgpt.com/codex/tasks/task_e_68c978d8bc8c8322bbee9b347af45461

## Summary by Sourcery

Enforce OBJ-only output defaults and ensure consistent network working folder configuration across all PhotoMesh Wizard installs by introducing a dedicated enforcer function, integrating it into startup and launch workflows, and upgrading the standalone config updater to cover additional install paths and surface permission issues.

New Features:
- Add enforce_wizard_obj_only_defaults function to force OBJ-only defaults and set NetworkWorkingFolder in PhotoMesh Wizard config
- Integrate the OBJ-only enforcer into toolkit startup, offline settings enforcement, and before each Wizard launch

Enhancements:
- Extend standalone update_photomesh_config script to include x86 install paths, disable non-OBJ formats, set VerticalDatum, and handle permission or parse errors more gracefully