### PR TITLE
Fix first-run setup prompts and improve offline share handling

### DIFF
--- a/PythonPorjects/STE_Toolkit.py
+++ b/PythonPorjects/STE_Toolkit.py
@@ -1724,7 +1724,9 @@ def first_run_setup(master=None) -> None:
         raise RuntimeError("First-run setup cancelled by user.")
 
     selected_root = os.path.normpath(selected_root)
-    share_root = os.path.join(selected_root, "SharedMeshDrive")
+    share_root = selected_root
+    if os.path.basename(share_root).lower() != "sharedmeshdrive":
+        share_root = os.path.join(selected_root, "SharedMeshDrive")
     log_to_console(f"[first-run] Shared drive root: {share_root}")
 
     os.makedirs(share_root, exist_ok=True)

--- a/PythonPorjects/config.ini
+++ b/PythonPorjects/config.ini
@@ -1,6 +1,6 @@
 [General]
 close_on_launch = False
-first_run_done = False
+first_run_done = True
 reality_mesh_local_root =
 default_browser = C:/Users/tifte/AppData/Local/Programs/Opera GX/opera.exe
 vbs4_path = C:\Builds\VBS4\VBS4 YYMEA_General\VBS4.exe
@@ -32,7 +32,7 @@ host_count = 1
 path = C:\BiSim OneClick\Datasets\CACTF_BUILD_20250814_134554
 
 [Offline]
-enabled = False
+enabled = True
 host_name = KIT1-1
 host_ip = 
 share_name = SharedMeshDrive

--- a/PythonPorjects/photomesh_launcher.py
+++ b/PythonPorjects/photomesh_launcher.py
@@ -31,6 +31,7 @@ import subprocess
 import sys
 import time
 import re
+import socket
 import xml.etree.ElementTree as ET
 from pathlib import Path
 from typing import Iterable
@@ -569,6 +570,11 @@ def _read_photomesh_host() -> str:
     return "KIT1-1"
 
 
+def get_machine_name() -> str:
+    """Return the current machine name without domain suffix."""
+    return socket.gethostname().split('.')[0].upper()
+
+
 def working_share_root() -> str:
     """UNC to the root share on the host (no hardcoded name)."""
     return rf"\\{_read_photomesh_host()}\SharedMeshDrive"
@@ -663,7 +669,7 @@ if (-not (Get-SmbShare -Name $share)) {{
 Get-NetFirewallRule -DisplayGroup 'File and Printer Sharing' | Where-Object {{$_.Profile -like '*Private*'}} | Enable-NetFirewallRule | Out-Null
 """
     try:
-        subprocess.run(
+        completed = subprocess.run(
             [
                 "powershell",
                 "-NoProfile",
@@ -672,13 +678,38 @@ Get-NetFirewallRule -DisplayGroup 'File and Printer Sharing' | Where-Object {{$_
                 "-Command",
                 ps,
             ],
+            capture_output=True,
+            text=True,
             check=False,
         )
-        log(f"Offline share ensured: \\\\{o['host_name']}\\{share}  ({root})")
     except Exception as e:
         log(
             f"Could not run PowerShell to ensure share: {e}\nPlease share {root} as '{share}' manually."
         )
+        return
+
+    if completed.returncode != 0:
+        err = completed.stderr.strip() or completed.stdout.strip() or str(completed.returncode)
+        log(f"SMB share creation failed: {err}")
+        return
+
+    check = subprocess.run(
+        [
+            "powershell",
+            "-NoProfile",
+            "-Command",
+            f"Get-SmbShare -Name '{share}' | Out-Null; $LASTEXITCODE",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if check.returncode != 0 or check.stderr.strip():
+        err = check.stderr.strip() or check.stdout.strip() or str(check.returncode)
+        log(f"SMB share '{share}' was not found after creation attempt. {err}")
+        return
+
+    log(f"Offline share ensured: \\\\{get_machine_name()}\\{share}  ({root})")
 
 
 def can_access_unc(path: str) -> bool:
@@ -884,20 +915,19 @@ def enforce_photomesh_settings(autostart: bool = True, log=print) -> None:
     unc = resolve_network_working_folder_from_cfg(o)  # \\hostOrIp\share\WorkingFuser
 
     # 3) Ensure folder exists (best effort)
-    share_ready = True
-    if unc and share_unc and not can_access_unc(share_unc):
-        share_ready = False
-        log(
-            "[Wizard] Missing share "
-            f"{share_unc} — skip creating WorkingFuser. "
-            "Use Settings→Offline→Test Access on the host to create/share it."
-        )
-
-    if unc and share_ready:
-        try:
-            os.makedirs(unc, exist_ok=True)
-        except Exception as e:  # pragma: no cover - best effort
-            log(f"[Wizard] Cannot create WorkingFuser at {unc}: {e}")
+    if unc:
+        host_short = o["host_name"].split(".")[0].upper()
+        machine = get_machine_name()
+        if machine == host_short:
+            ensure_offline_share_exists(log=log)
+            try:
+                os.makedirs(unc, exist_ok=True)
+            except Exception as e:  # pragma: no cover - best effort
+                log(f"[Wizard] Host could not create WorkingFuser at {unc}: {e}")
+        elif not can_access_unc(unc):
+            log(
+                f"[Wizard] Skipping WorkingFuser pre-create on non-host; {unc} not reachable yet."
+            )
 
     # 4) Enforce Wizard OBJ-only defaults and WorkingFuser UNC
     enforce_wizard_obj_only_defaults(log=log)

--- a/PythonPorjects/setup.iss
+++ b/PythonPorjects/setup.iss
@@ -113,6 +113,7 @@ begin
   SetIniString('SharedDrive', 'drive_letter', 'D:', Ini);
   SetIniString('SharedDrive', 'auto_map_on_save', 'True', Ini);
 
+  SetIniString('General', 'first_run_done', 'True', Ini);
   SetIniString('General', 'reality_mesh_local_root', Base + '\RealityMeshInstall', Ini);
 
   SetIniString('Fusers', 'desired_count', '3', Ini);


### PR DESCRIPTION
## Summary
- seed installer config with completed first-run state and enabled offline defaults
- stop the first-run wizard from double-appending the SharedMeshDrive folder
- harden offline share creation logging and skip WorkingFuser pre-creation when the UNC is unreachable on non-host machines

## Testing
- python -m compileall PythonPorjects/STE_Toolkit.py PythonPorjects/photomesh_launcher.py

------
https://chatgpt.com/codex/tasks/task_e_68c9c07d331083229229d63e79057860

## Summary by Sourcery

Improve first-run setup and offline share management by seeding config to skip the wizard, fixing SharedMeshDrive path logic, and hardening SMB share creation with detailed error handling and host-aware pre-creation.

Bug Fixes:
- Prevent first-run setup from appending "SharedMeshDrive" twice.

Enhancements:
- Seed installer and config.ini with first-run completed and offline enabled by default.
- Add get_machine_name() utility and validate SMB share creation in ensure_offline_share_exists with detailed logging.
- Only perform WorkingFuser pre-creation on the host machine, skipping unreachable UNC on non-hosts.