### PR TITLE
Ensure installer share setup and first-run wiring

### DIFF
--- a/PythonPorjects/STE_Toolkit.py
+++ b/PythonPorjects/STE_Toolkit.py
@@ -2847,6 +2847,11 @@ class MainApp(tk.Tk):
 
         enforce_local_fuser_policy()
 
+        try:
+            apply_offline_settings()
+        except Exception as exc:
+            print("[first-run] apply_offline_settings:", exc)
+
         # Start by showing "Main"
         self.current = None
         self.show('Main')
@@ -4859,7 +4864,7 @@ class SettingsPanel(tk.Frame):
         self.controller = controller
 
         self.configure(bg="black")
-        self.grid_rowconfigure(5, weight=1)
+        self.grid_rowconfigure(5, weight=1, minsize=600)
         self.grid_columnconfigure(0, weight=1)
 
         tk.Label(
@@ -5131,14 +5136,18 @@ class SettingsPanel(tk.Frame):
             font=("Helvetica", 16),
         )
         locs_box.grid(row=5, column=0, sticky="nsew", padx=10, pady=(0, 10))
-        self.grid_rowconfigure(5, weight=1, minsize=420)
+        self.grid_rowconfigure(5, weight=1, minsize=600)
 
         canvas = tk.Canvas(locs_box, bg="black", highlightthickness=0)
         vbar = tk.Scrollbar(locs_box, orient="vertical", command=canvas.yview)
         inner = tk.Frame(canvas, bg="black")
+        win_id = canvas.create_window((0, 0), window=inner, anchor="nw")
 
+        def _on_canvas_resize(evt):
+            canvas.itemconfig(win_id, width=evt.width)
+
+        canvas.bind("<Configure>", _on_canvas_resize)
         inner.bind("<Configure>", lambda e: canvas.configure(scrollregion=canvas.bbox("all")))
-        canvas.create_window((0, 0), window=inner, anchor="nw")
         canvas.configure(yscrollcommand=vbar.set)
 
         canvas.pack(side="left", fill="both", expand=True)
@@ -5199,6 +5208,8 @@ class SettingsPanel(tk.Frame):
             get_oneclick_output_path(),
             parent=inner,
         )
+
+        tk.Frame(inner, height=80, bg="black").pack(fill="x")
 
         # Back button and tutorial
         tk.Button(

--- a/PythonPorjects/setup.iss
+++ b/PythonPorjects/setup.iss
@@ -94,12 +94,37 @@ begin
   Result := Base;
 end;
 
+procedure EnsureSmbShare(ShareName, LocalPath: string);
+var
+  RC: Integer;
+  Cmd, EscShare, EscPath: string;
+begin
+  EscShare := ShareName;
+  EscPath := LocalPath;
+  StringChangeEx(EscShare, '''', '''''', True);
+  StringChangeEx(EscPath, '''', '''''', True);
+  Cmd :=
+    '-NoProfile -ExecutionPolicy Bypass -Command ' +
+    '"$ErrorActionPreference=''Stop''; ' +
+    'if (-not (Get-SmbShare -Name ''' + EscShare + ''' -ErrorAction SilentlyContinue)) { ' +
+    '  New-SmbShare -Name ''' + EscShare + ''' -Path ''' + EscPath + ''' -FullAccess ''Everyone'' | Out-Null ' +
+    '}; ' +
+    'Get-NetFirewallRule -DisplayGroup ''File and Printer Sharing'' | ' +
+    '  Where-Object {$_.Profile -like ''*Private*''} | Enable-NetFirewallRule | Out-Null"';
+
+  Exec(
+    ExpandConstant('{sys}\WindowsPowerShell\v1.0\powershell.exe'),
+    Cmd,
+    '', SW_HIDE, ewWaitUntilTerminated, RC);
+end;
+
 procedure SeedConfigIni(AppDir, ShareRoot: string);
 var
   Ini, Base: string;
 begin
   Ini  := AppDir + '\config.ini';
   Base := ForceLayoutUnder(ShareRoot);
+  EnsureSmbShare('SharedMeshDrive', Base);
 
   SetIniString('Offline', 'enabled', 'True', Ini);
   SetIniString('Offline', 'host_name', ExpandConstant('{computername}'), Ini);


### PR DESCRIPTION
## Summary
- add an Inno Setup helper that provisions the SharedMeshDrive SMB share during first-time installs
- run apply_offline_settings() when the GUI boots to sync offline defaults on the first launch
- widen the Settings panel application list viewport so the VBS License Manager row can scroll fully into view

## Testing
- python -m compileall PythonPorjects

------
https://chatgpt.com/codex/tasks/task_e_68c9c91afc488322bac739f69a842f2c

## Summary by Sourcery

Ensure the SharedMeshDrive SMB share is provisioned during install, apply offline settings on first run, and improve scrolling in the Settings panel

New Features:
- Add an Inno Setup helper to create and configure the SharedMeshDrive SMB share during installation
- Invoke apply_offline_settings() on GUI startup to apply offline defaults on first launch

Enhancements:
- Widen and dynamically resize the Settings panel’s application list viewport for full row scrolling