### PR TITLE
Align One-Click UI and setup handling

### DIFF
--- a/PythonPorjects/STE_Toolkit.py
+++ b/PythonPorjects/STE_Toolkit.py
@@ -3895,8 +3895,6 @@ class VBS4Panel(tk.Frame):
         self.log_message(f"Creating mesh for project: {project_name}")
 
         try:
-            apply_offline_settings()            # Wizard NetworkWorkingFolder + fuser shared_path
-            update_fuser_shared_path()          # belt and suspenders
             pmpreset_path = _resource_path("STEPRESET.PMPreset")
             try:
                 install_pmpreset(pmpreset_path, name="STEPRESET", log=self.log_message)
@@ -4186,17 +4184,15 @@ class OneClickPanel(tk.Frame):
         btn_frame = tk.Frame(self, bg="black")
         btn_frame.pack(pady=20)
 
-        pb = globals().get("pill_button")
-
         def make_button(text, command):
-            if pb:
-                return pb(btn_frame, text, command)
             return tk.Button(
                 btn_frame,
                 text=text,
                 font=("Helvetica", 24),
                 bg="#444444",
                 fg="white",
+                activebackground="#666666",
+                activeforeground="white",
                 width=30,
                 height=1,
                 command=command,
@@ -4620,6 +4616,7 @@ class OneClickPanel(tk.Frame):
 
         try:
             apply_offline_settings()
+            enforce_wizard_obj_only_defaults(log=self.log_message)
             update_fuser_shared_path()
             pmpreset_path = _resource_path("STEPRESET.PMPreset")
             try:


### PR DESCRIPTION
## Summary
- make the One-Click panel buttons use the same flat dark style as other panels
- ensure the One-Click pipeline enforces Wizard OBJ-only defaults before launching PhotoMesh
- remove redundant PhotoMesh configuration calls from the VBS4 panel so the One-Click panel owns the workflow

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68c9dc5725a48322867c432f8a03840a

## Summary by Sourcery

Align One-Click panel styling and centralize PhotoMesh setup

New Features:
- Add enforcement of Wizard OBJ-only defaults in the One-Click pipeline before launching PhotoMesh

Enhancements:
- Restyle One-Click panel buttons to use the same flat dark theme as other panels
- Remove redundant PhotoMesh setup calls from the VBS4 panel to avoid duplicate configuration