### PR TITLE
Gate RM launch until PhotoMesh OBJ export and disable Wizard Ortho outputs

### DIFF
--- a/PythonPorjects/STE_Toolkit.py
+++ b/PythonPorjects/STE_Toolkit.py
@@ -4025,20 +4025,23 @@ class VBS4Panel(tk.Frame):
             )
             return
 
-        # Fire-and-forget: launch Reality Mesh immediately after starting PhotoMesh
         def _pipeline():
-            # No gating on Output-CenterPivotOrigin.json / OBJ / TerraExplorer
-            def launch_rm():
-                try:
-                    self.log_message("Launching Reality Mesh to VBS4 (no checks)...")
-                    # Pass a hint path if you want; or None to just open the app
-                    self.post_process_last_build(self.last_build_dir)
-                    self.log_message("Reality Mesh to VBS4 launched.")
-                except Exception as exc:
-                    self.log_message(f"Launch failed: {exc}")
-                    messagebox.showerror("Launch Error", str(exc), parent=self)
-
-            self.after(0, launch_rm)
+            # Wait until PhotoMesh has actually exported OBJ tiles before launching RM.
+            build_root = self.last_build_dir  # project root that contains Build_* folders
+            self.log_message(
+                "Waiting for PhotoMesh build to complete (watching for OBJ output)…"
+            )
+            obj_dir = wait_for_obj(build_root, log=self.log_message)
+            if obj_dir:
+                self.log_message(
+                    f"PhotoMesh build complete (OBJ found at: {obj_dir}). Launching Reality Mesh…"
+                )
+                # Kick off post-processing / launch RM now that OBJ is present
+                self.post_process_last_build(build_root)
+            else:
+                self.log_message(
+                    "Timeout or failure while waiting for OBJ. Reality Mesh will NOT be launched."
+                )
 
         run_in_thread(_pipeline)
 
@@ -4734,16 +4737,22 @@ class OneClickPanel(tk.Frame):
             return
 
         def _pipeline():
-            def launch_rm():
-                try:
-                    self.log_message("Launching Reality Mesh to VBS4 (no checks)...")
-                    self.post_process_last_build(self.last_build_dir)
-                    self.log_message("Reality Mesh to VBS4 launched.")
-                except Exception as exc:
-                    self.log_message(f"Launch failed: {exc}")
-                    messagebox.showerror("Launch Error", str(exc), parent=self)
-
-            self.after(0, launch_rm)
+            # Wait until PhotoMesh has actually exported OBJ tiles before launching RM.
+            build_root = self.last_build_dir  # project root that contains Build_* folders
+            self.log_message(
+                "Waiting for PhotoMesh build to complete (watching for OBJ output)…"
+            )
+            obj_dir = wait_for_obj(build_root, log=self.log_message)
+            if obj_dir:
+                self.log_message(
+                    f"PhotoMesh build complete (OBJ found at: {obj_dir}). Launching Reality Mesh…"
+                )
+                # Kick off post-processing / launch RM now that OBJ is present
+                self.post_process_last_build(build_root)
+            else:
+                self.log_message(
+                    "Timeout or failure while waiting for OBJ. Reality Mesh will NOT be launched."
+                )
 
         run_in_thread(_pipeline)
 

--- a/PythonPorjects/photomesh_launcher.py
+++ b/PythonPorjects/photomesh_launcher.py
@@ -466,18 +466,29 @@ def enforce_wizard_obj_only_defaults(log=print) -> None:
         try:
             cfg = _load_json(path) or {}
             ui = cfg.setdefault("DefaultPhotoMeshWizardUI", {})
-            ui.setdefault("OutputProducts", {}).update({"Model3D": True})
+
+            # 1) Ensure Model3D output is enabled (OBJ enforced below)
+            op = ui.setdefault("OutputProducts", {})
+            op["Model3D"] = True
+
+            # 2) Disable Ortho without clobbering unrelated OutputProducts keys.
+            for ortho_key in ("Orthophoto", "2DOrtho", "Ortho", "OrthoMap"):
+                op.setdefault(ortho_key, False)
+                op[ortho_key] = False
+
+            # 3) OBJ-only model formats
             fmts = ui.setdefault("Model3DFormats", {})
             fmts["OBJ"] = True
             fmts["3DML"] = False
             fmts["SLPK"] = False
+
             ui.setdefault("VerticalDatum", "Ellipsoid")
 
             if working_unc:
                 cfg["NetworkWorkingFolder"] = working_unc
 
             _save_json(path, cfg)
-            log(f"[Wizard 1.5.1] OBJ-only + WorkingFolder set -> {path}")
+            log(f"[Wizard 1.5.1] OBJ-only/Ortho-off + WorkingFolder set -> {path}")
         except PermissionError:
             log(f"[Wizard 1.5.1] No permission to write {path}. Run as Administrator.")
         except Exception as exc:


### PR DESCRIPTION
## Summary
- wait for PhotoMesh OBJ export to complete before launching Reality Mesh in both one-click flows
- enforce PhotoMesh Wizard defaults that keep OBJ output on and disable Ortho keys without overwriting unrelated settings

## Testing
- not run (UI-driven change)


------
https://chatgpt.com/codex/tasks/task_e_68cad0fd082883228c99813787c8cd15

## Summary by Sourcery

Wait for PhotoMesh OBJ export to complete before launching Reality Mesh in one-click conversion flows, and update PhotoMesh Wizard defaults to enable OBJ output only and disable orthophoto outputs without altering unrelated settings.

Enhancements:
- Delay Reality Mesh launch until PhotoMesh has exported OBJ tiles using wait_for_obj in both one-click conversion pipelines
- Enforce PhotoMesh Wizard defaults to enable only OBJ model output, disable orthophoto outputs, and preserve unrelated settings