### PR TITLE
Hide PowerShell consoles for toolkit and launcher

### DIFF
--- a/PythonPorjects/STE_Toolkit.py
+++ b/PythonPorjects/STE_Toolkit.py
@@ -997,16 +997,21 @@ def write_project_settings(settings_path: str, data: dict, data_folder: str) -> 
 
 
 def run_processor(ps_script: str, settings_path: str, log_func=lambda msg: None) -> None:
-    """Run the Reality Mesh PowerShell script via a project-specific batch file."""
-    batch_path = os.path.join(os.path.dirname(settings_path), 'RealityMeshProcess.bat')
+    """Run the Reality Mesh PowerShell script silently (no visible console)."""
+    if not os.path.isfile(ps_script):
+        raise FileNotFoundError(f'PowerShell script not found: {ps_script}')
 
-    with open(batch_path, 'w', encoding='utf-8') as f:
-        f.write(
-            f'start "" powershell -executionpolicy bypass "{ps_script}" "{settings_path}" 1\n'
-        )
-
-    log_func(f'Created batch file {batch_path}')
-    subprocess.run(batch_path, check=True)
+    cmd = [
+        "powershell",
+        "-NoProfile",
+        "-WindowStyle", "Hidden",
+        "-ExecutionPolicy", "Bypass",
+        "-File", ps_script,
+        settings_path,
+        "1",
+    ]
+    log_func(f"[processor] {' '.join(cmd)} (hidden)")
+    subprocess.run(cmd, check=True, creationflags=NO_WINDOW_FLAG)
 
 
 def run_remote_processor(ps_script: str, target_ip: str, settings_path: str,
@@ -1020,13 +1025,15 @@ def run_remote_processor(ps_script: str, target_ip: str, settings_path: str,
     if not os.path.isfile(ps_script):
         raise FileNotFoundError(f'PowerShell script not found: {ps_script}')
     cmd = [
-        'powershell',
-        '-ExecutionPolicy', 'Bypass',
-        '-File', ps_script,
+        "powershell",
+        "-NoProfile",
+        "-WindowStyle", "Hidden",
+        "-ExecutionPolicy", "Bypass",
+        "-File", ps_script,
         target_ip,
         settings_path,
     ]
-    log_func('Running: ' + ' '.join(cmd))
+    log_func('Running (hidden): ' + ' '.join(cmd))
     env = os.environ.copy()
     env["PYTHONIOENCODING"] = "utf-8"
     with subprocess.Popen(
@@ -1038,6 +1045,7 @@ def run_remote_processor(ps_script: str, target_ip: str, settings_path: str,
         errors="replace",
         env=env,
         bufsize=1,
+        creationflags=NO_WINDOW_FLAG,
     ) as proc:
         for line in proc.stdout:
             line = line.rstrip("\r\n")

--- a/PythonPorjects/photomesh_launcher.py
+++ b/PythonPorjects/photomesh_launcher.py
@@ -49,6 +49,9 @@ except Exception:  # pragma: no cover - headless/test environments
     messagebox = None
 # endregion
 
+# Hide consoles for child processes on Windows
+NO_WINDOW_FLAG = getattr(subprocess, "CREATE_NO_WINDOW", 0)
+
 # region Constants & Configuration
 # Authoritative Wizard locations
 WIZARD_DIR = r"C:\\Program Files\\Skyline\\PhotoMesh\\Tools\\PhotomeshWizard"
@@ -696,7 +699,7 @@ def ensure_offline_share_via_cmd(log=print) -> None:
         subprocess.run(
             ["cmd", "/C", f'net share {share}="{root}" /GRANT:Everyone,FULL'],
             check=False,
-            creationflags=getattr(subprocess, "CREATE_NO_WINDOW", 0),
+            creationflags=NO_WINDOW_FLAG,
         )
         subprocess.run(
             [
@@ -705,7 +708,7 @@ def ensure_offline_share_via_cmd(log=print) -> None:
                 'netsh advfirewall firewall set rule group="File and Printer Sharing" new enable=Yes',
             ],
             check=False,
-            creationflags=getattr(subprocess, "CREATE_NO_WINDOW", 0),
+            creationflags=NO_WINDOW_FLAG,
         )
         log(
             f"Offline share ensured via CMD: \{get_machine_name()}\{share}  ({root})"
@@ -787,6 +790,7 @@ def list_remote_shares(host: str) -> list[str]:
             capture_output=True,
             text=True,
             check=False,
+            creationflags=NO_WINDOW_FLAG,
         ).stdout
         return [m.group(1) for m in _DRIVE_RE.finditer(out)]
     except Exception:
@@ -849,7 +853,11 @@ def current_mapping(letter: str = "M:") -> str | None:
     r"""Return the UNC path mapped to *letter*, if any."""
     try:
         out = subprocess.run(
-            ["net", "use"], capture_output=True, text=True, check=False
+            ["net", "use"],
+            capture_output=True,
+            text=True,
+            check=False,
+            creationflags=NO_WINDOW_FLAG,
         ).stdout
         pattern = re.compile(rf"^\s*{re.escape(letter)}\s+(\\\\\\S+)", re.MULTILINE | re.IGNORECASE)
         m = pattern.search(out)
@@ -860,7 +868,11 @@ def current_mapping(letter: str = "M:") -> str | None:
 
 def unmap_drive(letter: str = "M:") -> None:
     r"""Unmap drive *letter* using ``net use``."""
-    subprocess.run(["net", "use", letter, "/delete", "/yes"], check=False)
+    subprocess.run(
+        ["net", "use", letter, "/delete", "/yes"],
+        check=False,
+        creationflags=NO_WINDOW_FLAG,
+    )
 
 
 def map_drive(unc: str, letter: str = "M:") -> bool:
@@ -871,6 +883,7 @@ def map_drive(unc: str, letter: str = "M:") -> bool:
     subprocess.run(
         ["net", "use", letter, unc, "/persistent:yes"],
         check=False,
+        creationflags=NO_WINDOW_FLAG,
     )
     target = os.path.join(letter, "")
     return os.path.isdir(target) and can_access_unc(unc)
@@ -1005,20 +1018,21 @@ def run_exe_as_admin_blocking(
     """Run elevated process and wait for completion via PowerShell Start-Process."""
     args = args or []
     argline = " ".join([f'"{a}"' for a in args])
+    command = (
+        f'Start-Process "{exe_path}" -ArgumentList "{argline}" '
+        "-Verb RunAs -Wait"
+    )
     ps = [
         "powershell",
         "-NoProfile",
+        "-WindowStyle",
+        "Hidden",
         "-ExecutionPolicy",
         "Bypass",
-        "Start-Process",
-        f'"{exe_path}"',
-        "-ArgumentList",
-        f'"{argline}"',
-        "-Verb",
-        "RunAs",
-        "-Wait",
+        "-Command",
+        command,
     ]
-    subprocess.run(ps, check=True, cwd=cwd or None)
+    subprocess.run(ps, check=True, cwd=cwd or None, creationflags=NO_WINDOW_FLAG)
 
 
 def launch_photomesh_admin() -> None:


### PR DESCRIPTION
## Summary
- run Reality Mesh processor workflows through hidden PowerShell invocations that share a no-window creation flag
- add a reusable CREATE_NO_WINDOW flag in the PhotoMesh launcher and apply it to PowerShell, cmd, and net commands, including the admin elevation helper

## Testing
- python -m compileall PythonPorjects/STE_Toolkit.py PythonPorjects/photomesh_launcher.py

------
https://chatgpt.com/codex/tasks/task_e_68cc064ea56483229039213c7a56ca7a

## Summary by Sourcery

Hide PowerShell consoles for the PhotoMesh launcher and STE Toolkit by introducing a reusable no-window flag and applying it to all relevant subprocess invocations.

Enhancements:
- Add a reusable NO_WINDOW_FLAG constant for suppressing console windows on Windows subprocesses
- Apply NO_WINDOW_FLAG to all cmd, net, netsh, drive mapping/unmapping, and admin elevation subprocess calls
- Update run_exe_as_admin to launch elevated processes with hidden PowerShell windows
- Refactor run_processor to run PowerShell scripts directly in hidden mode with file existence validation
- Modify run_remote_processor to invoke remote PowerShell scripts hidden and apply NO_WINDOW_FLAG to Popen