### PR TITLE
Switch UNC handling to host IP addresses

### DIFF
--- a/PythonPorjects/STE_Toolkit.py
+++ b/PythonPorjects/STE_Toolkit.py
@@ -1332,6 +1332,7 @@ def bootstrap_first_run_if_needed(log=None):
             ip = get_primary_ipv4()
             if ip:
                 o['host_ip'] = ip
+        o['use_ip_unc'] = 'True'
         root = o.get('local_data_root') or ''
         if root:
             ensure_sharedmesh_share(root, "SharedMeshDrive", log=log or (lambda m: None))
@@ -1658,6 +1659,8 @@ def update_fuser_shared_path(project_path: str | None = None) -> None:
     path = resolve_network_working_folder_from_cfg(get_offline_cfg())
     if project_path and project_path.startswith('\\'):
         path = project_path
+    if not path:
+        return
 
     try:
         with open(cfg_path, 'r') as f:
@@ -1671,6 +1674,7 @@ def update_fuser_shared_path(project_path: str | None = None) -> None:
     try:
         with open(cfg_path, 'w') as f:
             json.dump(data, f, indent=2)
+        logging.info(f"[fuser] shared_path -> {path}")
     except Exception as e:
         logging.error("Failed to update fuser config: %s", e)
 
@@ -1693,7 +1697,12 @@ def apply_offline_settings() -> None:
     if _is_offline_enabled():
         o = get_offline_cfg()
         local_name = get_machine_name()
-        if local_name.upper() == o["host_name"].split('.')[0].upper():
+        host_short = o["host_name"].split('.')[0].upper() if o.get("host_name") else ""
+        host_ip = (o.get("host_ip") or "").strip()
+        local_ip = get_primary_ipv4()
+        if host_ip and local_ip and host_ip == local_ip:
+            ensure_offline_share_exists()
+        elif host_short and local_name.upper() == host_short:
             ensure_offline_share_exists()
 
     enforce_local_fuser_policy()
@@ -5317,38 +5326,55 @@ class SettingsPanel(tk.Frame):
         net_frame.grid(row=3, column=0, sticky="ew", padx=10, pady=(0, 6))
         net_frame.grid_columnconfigure(1, weight=1)
 
-        tk.Label(net_frame, text="Host PC Name", font=("Helvetica", 14), bg="black", fg="white") \
-            .grid(row=0, column=0, columnspan=3, sticky="w")
+        tk.Label(
+            net_frame,
+            text="Host IP",
+            font=("Helvetica", 14),
+            bg="black",
+            fg="white",
+        ).grid(row=0, column=0, columnspan=2, sticky="w")
 
         host_row = tk.Frame(net_frame, bg="black")
-        host_row.grid(row=1, column=0, columnspan=3, sticky="ew", pady=(2, 10))
-        self.host_var = tk.StringVar(value=get_host())
+        host_row.grid(row=1, column=0, columnspan=2, sticky="ew", pady=(2, 10))
 
-        entry = tk.Entry(
+        self.host_ip_var = tk.StringVar(
+            value=config.get("Offline", "host_ip", fallback="")
+        )
+
+        tk.Entry(
             host_row,
-            textvariable=self.host_var,
+            textvariable=self.host_ip_var,
             font=("Consolas", 12),
             bg="#111111",
             fg="white",
             insertbackground="white",
             bd=0,
-        )
-        entry.pack(side="left", fill="x", expand=True)
+        ).pack(side="left", fill="x", expand=True)
 
-        def _fill_pc_name():
-            import platform
+        def _use_my_ip():
+            ip = get_primary_ipv4()
+            if ip:
+                self.host_ip_var.set(ip)
 
-            pc = platform.node().strip()
-            if pc:
-                self.host_var.set(pc)
+        tk.Button(
+            host_row,
+            text="Use my IP",
+            command=_use_my_ip,
+            font=("Helvetica", 12),
+            bg="#444444",
+            fg="white",
+            bd=0,
+        ).pack(side="left", padx=8)
 
-        tk.Button(host_row, text="Set as Host", command=_fill_pc_name,
-                  font=("Helvetica", 12), bg="#444444", fg="white", bd=0) \
-            .pack(side="left", padx=8)
-
-        tk.Button(host_row, text="Save", command=self._save_host,
-                  font=("Helvetica", 12), bg="#444444", fg="white", bd=0) \
-            .pack(side="left", padx=8)
+        tk.Button(
+            host_row,
+            text="Save",
+            command=self._save_host_ip,
+            font=("Helvetica", 12),
+            bg="#444444",
+            fg="white",
+            bd=0,
+        ).pack(side="left", padx=8)
 
         # Provide a “Share Now” action to (re)publish the folder silently
         def _share_now():
@@ -5648,15 +5674,15 @@ class SettingsPanel(tk.Frame):
     def reload_from_config(self):
         """Synchronize all Settings inputs with the persisted configuration."""
 
-        self.host_var.set(get_host())
-
         off = get_offline_cfg()
+        if hasattr(self, "host_ip_var"):
+            self.host_ip_var.set(off["host_ip"])
         self.off_enabled.set(bool(off["enabled"]))
         self.off_host_ip.set(off["host_ip"])
         self.off_share_name.set(off["share_name"])
         self.off_local_root.set(off["local_data_root"])
         self.off_work_subdir.set(off["working_fuser_subdir"])
-        self.off_use_ip_unc.set(bool(off["use_ip_unc"]))
+        self.off_use_ip_unc.set(True)
 
         sd = config["SharedDrive"] if "SharedDrive" in config else {}
         preferred = str(sd.get("preferred_mode", "UNC")).upper()
@@ -5710,7 +5736,8 @@ class SettingsPanel(tk.Frame):
         o["share_name"] = self.off_share_name.get().strip()
         o["local_data_root"] = os.path.normpath(self.off_local_root.get().strip())
         o["working_fuser_subdir"] = self.off_work_subdir.get().strip()
-        o["use_ip_unc"] = str(bool(self.off_use_ip_unc.get()))
+        o["use_ip_unc"] = "True"
+        self.off_use_ip_unc.set(True)
 
         sd = config.setdefault("SharedDrive", {})
         sd["preferred_mode"] = self.shared_mode.get()
@@ -5733,7 +5760,7 @@ class SettingsPanel(tk.Frame):
 
                 if self.shared_auto_map.get():
                     unc_root = build_unc_from_cfg(o)
-                    if map_drive(unc_root, sd["drive_letter"]):
+                    if unc_root and map_drive(unc_root, sd["drive_letter"]):
                         def _apply_map():
                             self.shared_mode.set("DRIVE")
                             sd["preferred_mode"] = "DRIVE"
@@ -5758,6 +5785,12 @@ class SettingsPanel(tk.Frame):
 
     def _test_offline_access(self):
         path = resolve_shared_access_path()
+        if not path:
+            messagebox.showinfo(
+                "Test Access",
+                "Host IP is not configured. Set it above to test the shared folder.",
+            )
+            return
         working = tk.Toplevel(self)
         working.title("Working…")
         tk.Label(working, text="Working…", padx=20, pady=20).pack()
@@ -5778,7 +5811,7 @@ class SettingsPanel(tk.Frame):
                         " • Ensure all PCs are on the same switch\n",
                         " • Static IPs (e.g., 192.168.50.10/24 host)\n",
                         " • Share exists and permissions allow read/write\n",
-                        " • Try toggling 'Use IP in UNC' or add host to hosts file",
+                        " • Confirm the Host IP above matches the host PC",
                     )
 
             post_ui(_done)
@@ -5809,7 +5842,11 @@ class SettingsPanel(tk.Frame):
             messagebox.showerror("Open Working Folder", f"Cannot access:\n{path}\nUse Test Access to diagnose.")
 
     def _auto_find_share(self):
-        host = get_host().strip()
+        o = get_offline_cfg()
+        host = (o.get("host_ip") or "").strip() or get_host().strip()
+        if not host:
+            messagebox.showerror("Auto-Find Share", "Host IP or name is not configured.")
+            return
         res = probe_best_mesh_share(host)
         if not res:
             messagebox.showerror("Auto-Find Share", f"No share found on {host}")
@@ -5832,6 +5869,12 @@ class SettingsPanel(tk.Frame):
         o = get_offline_cfg()
         letter = self.shared_letter.get().strip() or "M:"
         unc = build_unc_from_cfg(o)
+        if not unc:
+            messagebox.showerror(
+                "Map Drive",
+                "Host IP is not set. Please enter it above before mapping.",
+            )
+            return
         if map_drive(unc, letter):
             self.shared_mode.set("DRIVE")
             sd = config.setdefault("SharedDrive", {})
@@ -5855,29 +5898,25 @@ class SettingsPanel(tk.Frame):
         self.shared_mode.set("UNC")
         logging.info(f"Unmapped {letter}")
         messagebox.showinfo("Map Drive", f"Unmapped {letter}")
-    def _save_host(self):
-        h = self.host_var.get().strip()
-        if not h:
-            messagebox.showerror("Settings", "Host name cannot be empty.")
-            return
-        set_host(h)  # updates Offline.host_name + related fields
-        o = config.setdefault('Offline', {})
-        if not o.get('host_ip'):
-            ip = get_primary_ipv4()
-            if ip:
-                o['host_ip'] = ip
-        sd = config.setdefault('SharedDrive', {})
-        sd['preferred_mode'] = 'UNC'
+    def _save_host_ip(self):
+        ip = self.host_ip_var.get().strip()
+        if "Offline" not in config:
+            config["Offline"] = {}
+        offline = config["Offline"]
+        offline["host_ip"] = ip
+        offline["use_ip_unc"] = "True"
         with open(CONFIG_PATH, "w", encoding="utf-8") as f:
             config.write(f)
-        enforce_local_fuser_policy()
-        apply_offline_settings()
-        pnl = self.controller.panels.get('VBS4')
-        if pnl and hasattr(pnl, "log_message"):
-            pnl.log_message(f"Host set to: {h}")
-        if pnl and hasattr(pnl, "_update_rm_status"):
-            pnl._update_rm_status()
-        messagebox.showinfo("Settings", f"Host set to '{h}'.")
+
+        if hasattr(self, "off_host_ip"):
+            self.off_host_ip.set(ip)
+
+        try:
+            apply_offline_settings()
+            update_fuser_shared_path()
+            messagebox.showinfo("Settings", f"Host IP set to: {ip or '[blank]'}")
+        except Exception as exc:
+            messagebox.showerror("Settings", str(exc))
 
     def _browse_rm_local_root(self):
         path = filedialog.askdirectory()

--- a/PythonPorjects/photomesh_launcher.py
+++ b/PythonPorjects/photomesh_launcher.py
@@ -37,6 +37,7 @@ from pathlib import Path
 from typing import Iterable
 import winreg  # for InstallLocation lookup
 import glob
+import logging
 
 try:  # pragma: no cover - optional dependency
     import requests  # type: ignore
@@ -51,6 +52,48 @@ except Exception:  # pragma: no cover - headless/test environments
 
 # Hide consoles for child processes on Windows
 NO_WINDOW_FLAG = getattr(subprocess, "CREATE_NO_WINDOW", 0)
+
+
+def get_primary_ipv4() -> str:
+    """Return primary IPv4 without showing any console."""
+    try:
+        s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        s.connect(("8.8.8.8", 80))
+        ip = s.getsockname()[0]
+        s.close()
+        return ip
+    except Exception:
+        return ""
+
+
+def migrate_hostname_to_ip_once():
+    """
+    One-time migration: if host_ip is blank and host_name exists,
+    try to resolve hostname -> ip and persist. Set use_ip_unc=True.
+    """
+
+    o = get_offline_cfg()
+    if "Offline" not in config:
+        config["Offline"] = {}
+    offline = config["Offline"]
+
+    ip = (o.get("host_ip") or "").strip()
+    hn = (o.get("host_name") or "").strip()
+    changed = False
+    if not ip and hn:
+        try:
+            resolved = socket.gethostbyname(hn)
+            if resolved and resolved != "127.0.0.1":
+                offline["host_ip"] = resolved
+                changed = True
+        except Exception:
+            pass
+    if offline.get("use_ip_unc", "True") != "True":
+        offline["use_ip_unc"] = "True"
+        changed = True
+    if changed:
+        with open(CONFIG_PATH, "w", encoding="utf-8") as f:
+            config.write(f)
 
 # region Constants & Configuration
 # Authoritative Wizard locations
@@ -210,9 +253,9 @@ OFFLINE_ACCESS_HINT = (
     "Cannot access the shared working folder.\n\n"
     "Connect all PCs to the same switch, assign static IPs (e.g., host 192.168.50.10, "
     "clients 192.168.50.11-13, mask 255.255.255.0), ensure the same Workgroup "
-    "(e.g., WORKGROUP), share the local_data_root on the host as share_name with "
-    "read/write permissions, and if name resolution fails, enable use_ip_unc or add "
-    "host_name to C:\\Windows\\System32\\drivers\\etc\\hosts."
+    "(e.g., WORKGROUP), and share the local_data_root on the host as share_name "
+    "with read/write permissions. Set the Host IP in Settings so UNC paths use "
+    "the correct address."
 )
 RM_LNK_NAME = "Reality Mesh to VBS4.lnk"
 RM_INSTALL_SUBDIRS = ["RealityMeshInstall", "ReailityMeshInstall"]
@@ -602,13 +645,13 @@ def get_machine_name() -> str:
 
 
 def working_share_root() -> str:
-    """UNC to the root share on the host (no hardcoded name)."""
-    return rf"\\{_read_photomesh_host()}\SharedMeshDrive"
+    """UNC to the root share on the host (IP-based)."""
+    return build_unc_from_cfg(get_offline_cfg())
 
 
 def working_fuser_unc() -> str:
     """UNC path to the WorkingFuser subfolder."""
-    return os.path.join(working_share_root(), "WorkingFuser")
+    return resolve_network_working_folder_from_cfg(get_offline_cfg())
 
 
 def _is_offline_enabled() -> bool:
@@ -636,31 +679,49 @@ def get_offline_cfg() -> dict:
     return {
         "enabled": o.getboolean("enabled", False),
         "host_name": o.get("host_name", "KIT-HOST").strip(),
-        "host_ip": o.get("host_ip", "192.168.50.10").strip(),
+        "host_ip": o.get("host_ip", "").strip(),
         "share_name": o.get("share_name", "SharedMeshDrive").strip(),
         "local_data_root": os.path.normpath(
             o.get("local_data_root", r"D:\\SharedMeshDrive")
         ),
         "working_fuser_subdir": o.get("working_fuser_subdir", "WorkingFuser").strip(),
-        "use_ip_unc": o.getboolean("use_ip_unc", False),
+        "use_ip_unc": o.getboolean("use_ip_unc", True),
     }
 
 
+try:
+    migrate_hostname_to_ip_once()
+except Exception as e:  # pragma: no cover - best effort migration
+    logging.warning(f"[migrate] hostname->ip skipped: {e}")
+
+
 def build_unc_from_cfg(o: dict) -> str:
-    """Build a UNC path to the shared drive from offline config dict *o*."""
-    host = o["host_ip"] if o.get("use_ip_unc") else o["host_name"]
-    return rf"\\\\{host}\\{o['share_name']}"
+    """
+    Build UNC \\<IP>\share from Offline config, always preferring host_ip.
+    Returns an empty string if no host_ip is configured.
+    """
+
+    ip = (o.get("host_ip") or "").strip()
+    share = (o.get("share_name") or "SharedMeshDrive").strip()
+    if not ip:
+        return ""
+    return rf"\\{ip}\{share}"
 
 
 def working_fuser_unc_from_cfg(o: dict) -> str:
     """Return UNC path to WorkingFuser based on offline config dict *o*."""
-    return os.path.join(build_unc_from_cfg(o), o["working_fuser_subdir"])
+    return resolve_network_working_folder_from_cfg(o)
 
 
 def resolve_network_working_folder_from_cfg(o: dict) -> str:
-    """Resolve the network working folder UNC from config dict *o*."""
-    base = o["host_ip"] if o.get("use_ip_unc") else o["host_name"]
-    return rf"\\{base}\{o['share_name']}\{o['working_fuser_subdir']}"
+    """Returns UNC for WorkingFuser (\\<IP>\share\WorkingFuser)."""
+
+    unc = build_unc_from_cfg(o)
+    if not unc:
+        return ""
+    sub = (o.get("working_fuser_subdir") or "WorkingFuser").strip()
+    combined = os.path.normpath(os.path.join(unc, sub))
+    return combined.replace("/", "\\")
 
 
 def _resolve_share_root_from_offline(o: dict) -> tuple[str, str]:

--- a/PythonPorjects/update_photomesh_config.py
+++ b/PythonPorjects/update_photomesh_config.py
@@ -19,7 +19,6 @@
 # =============================================================================
 
 # region Imports
-import json
 import os
 import sys
 
@@ -30,6 +29,8 @@ if BASE_DIR not in sys.path:
 from photomesh_launcher import (
     get_offline_cfg,
     resolve_network_working_folder_from_cfg,
+    _load_json,
+    _save_json,
 )
 # endregion
 
@@ -54,36 +55,18 @@ CONFIGS = [
 # endregion
 
 # region File I/O & JSON helpers
-def _load_config(path: str) -> dict:
-    """Load JSON configuration from *path*."""
-    with open(path, "r", encoding="utf-8") as f:
-        return json.load(f)
-
-
-def _save_config(path: str, config: dict) -> None:
-    """Write JSON *config* to *path* atomically."""
-    tmp = path + ".tmp"
-    with open(tmp, "w", encoding="utf-8") as f:
-        json.dump(config, f, indent=4)
-    os.replace(tmp, path)
+# Shared via photomesh_launcher._load_json/_save_json
 # endregion
 
 # region Wizard Config
 def update_config(path: str) -> bool:
     """Force OBJ-only defaults and update NetworkWorkingFolder for Wizard 1.5.1."""
-    try:
-        config = _load_config(path)
-    except FileNotFoundError:
-        return False
-    except PermissionError as exc:
-        print(f"[Wizard 1.5.1] Permission denied reading {path}: {exc}")
-        print("Run this updater as Administrator.")
-        return False
-    except json.JSONDecodeError as exc:
-        print(f"[Wizard 1.5.1] Failed to parse {path}: {exc}")
+    if not os.path.isfile(path):
         return False
 
-    ui = config.setdefault("DefaultPhotoMeshWizardUI", {})
+    cfg = _load_json(path) or {}
+
+    ui = cfg.setdefault("DefaultPhotoMeshWizardUI", {})
     ui.setdefault("OutputProducts", {}).update({"Model3D": True})
     fmts = ui.setdefault("Model3DFormats", {})
     fmts["OBJ"] = True
@@ -91,19 +74,19 @@ def update_config(path: str) -> bool:
     fmts["SLPK"] = False
     ui.setdefault("VerticalDatum", "Ellipsoid")
 
+    unc = ""
     try:
-        config["NetworkWorkingFolder"] = resolve_network_working_folder_from_cfg(
-            get_offline_cfg()
-        )
+        unc = resolve_network_working_folder_from_cfg(get_offline_cfg())
     except Exception:
-        pass
+        unc = ""
+    if unc:
+        cfg["NetworkWorkingFolder"] = unc
 
     try:
-        _save_config(path, config)
-    except PermissionError:
-        print(
-            f"[Wizard 1.5.1] Permission denied writing {path}. Run as Administrator."
-        )
+        _save_json(path, cfg)
+    except PermissionError as exc:
+        print(f"[Wizard 1.5.1] Permission denied writing {path}: {exc}")
+        print("Run this updater as Administrator.")
         return False
     except Exception as exc:
         print(f"[Wizard 1.5.1] Failed updating {path}: {exc}")


### PR DESCRIPTION
## Summary
- prefer host IP values for UNC building and migrate legacy hostname configuration in the PhotoMesh launcher helpers
- update the settings panel to capture/sync host IPs, always write IP-based UNC paths, and harden drive mapping and access checks
- reuse the shared helpers in the PhotoMesh wizard updater so the working folder is written with the resolved host IP

## Testing
- python -m compileall PythonPorjects/photomesh_launcher.py PythonPorjects/STE_Toolkit.py PythonPorjects/update_photomesh_config.py

------
https://chatgpt.com/codex/tasks/task_e_68cc150864b48322ad1f9804f86c0f26

## Summary by Sourcery

Switch UNC path handling to use host IP addresses by default by migrating legacy host_name entries, refactoring UNC resolution functions, revamping the settings UI, and updating the PhotoMesh wizard updater with improved validation and logging.

New Features:
- Add get_primary_ipv4 helper and migrate_hostname_to_ip_once for one-time migration from host_name to host_ip
- Replace host name input with host IP entry, including a “Use my IP” button, and enforce IP-based UNC mapping in the settings UI

Enhancements:
- Refactor UNC path builders and shared folder functions to always prefer host_ip and return empty when unset
- Harden offline share logic and fuser updates with early returns, host_ip/local_ip validation, and logging
- Improve drive mapping and access checks with informative dialogs when host_ip is missing
- Update PhotoMesh wizard updater to use shared JSON helpers and apply IP-based UNC for NetworkWorkingFolder